### PR TITLE
CMake: Ensure abc executable depends on libabc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,16 @@ function(abc_properties target visibility)
     target_link_libraries(${target} ${visibility} ${ABC_LIBS})
 endfunction()
 
-add_executable(abc ${ABC_SRC})
-abc_properties(abc PRIVATE)
-
-list(REMOVE_ITEM ABC_SRC src/base/main/main.c)
+set(ABC_MAIN_SRC src/base/main/main.c)
+list(REMOVE_ITEM ABC_SRC ${ABC_MAIN_SRC})
 
 add_library(libabc EXCLUDE_FROM_ALL ${ABC_SRC})
 abc_properties(libabc PUBLIC)
 set_property(TARGET libabc PROPERTY OUTPUT_NAME abc)
+
+add_executable(abc ${ABC_MAIN_SRC})
+target_link_libraries(abc PRIVATE libabc)
+abc_properties(abc PRIVATE)
 
 add_library(libabc-pic EXCLUDE_FROM_ALL ${ABC_SRC})
 abc_properties(libabc-pic PUBLIC)


### PR DESCRIPTION
**Background**
In projects like [VTR](https://github.com/verilog-to-routing/vtr-verilog-to-routing) we use both the `abc` executable, and `libabc` library.

**Issue**
With ABC's current CMakeLists.txt the object files for libabc are built twice: 
1. for the abc executable target,
2. for the libabc target.

**Fix**
This change adds `libabc` to `abc`'s link libraries, so the object files for `libabc` are only built once.
This matches the existing behaviour of ABC's Makefiles, where each object file is built once.

Note that the build process for `libabc-pic` is unchanged.

**Testing**
All CMake targets (`abc`, `libabc`, `libabc-pic`) compile correctly.
Building `abc` and `libabc` together takes half the wall-clock time.