### PR TITLE
Add a link to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 ABC is always changing but the current snapshot is believed to be stable. 
 
+For an introduction to ABC, visit the [ABC website](http://people.eecs.berkeley.edu/~alanmi/abc/).
+
 ## Compiling:
 
 To compile ABC as a binary, download and unzip the code, then type `make`.


### PR DESCRIPTION
I discovered this repository through a search and was not already familiar with ABC.  This patch adds a link to the README for people who need an introduction.  

I recommend also adding the link to the GitHub repository settings (click "Edit" at the top right and put the URL into the "Website" field that appears).  It will then appear at the top of the page next to the description.