### PR TITLE
CMake: Add option to build ABC binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ include(CMakeParseArguments)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
+# options for ABC
+option(ABC_BUILD_BINARY "Build the ABC binary" ON)
+
 function(addprefix var prefix)
     foreach( s ${ARGN} )
         list(APPEND tmp "-I${s}")
@@ -95,9 +98,11 @@ add_library(libabc EXCLUDE_FROM_ALL ${ABC_SRC})
 abc_properties(libabc PUBLIC)
 set_property(TARGET libabc PROPERTY OUTPUT_NAME abc)
 
-add_executable(abc ${ABC_MAIN_SRC})
-target_link_libraries(abc PRIVATE libabc)
-abc_properties(abc PRIVATE)
+if(ABC_BUILD_BINARY)
+    add_executable(abc ${ABC_MAIN_SRC})
+    target_link_libraries(abc PRIVATE libabc)
+    abc_properties(abc PRIVATE)
+endif()
 
 add_library(libabc-pic EXCLUDE_FROM_ALL ${ABC_SRC})
 abc_properties(libabc-pic PUBLIC)


### PR DESCRIPTION
In our project, we use ABC as a library integrated with the CMake build system. However, we only need the `libabc` library and not the `abc` binary. Currently, the binary is always generated and placed into the binary output folder.

With this change, one can exclude building the binary by setting the option as follows before including the CMake file from abc:
```
set (ABC_BUILD_BINARY OFF CACHE BOOL "Build the ABC binary")
add_subdirectory (abc)
```

As the default option is to build the binary, this should not break any existing builds.