### PR TITLE
64-bit alignment problem

### DIFF
--- a/src/opt/sim/simMan.c
+++ b/src/opt/sim/simMan.c
@@ -80,7 +80,7 @@ Sym_Man_t * Sym_ManStart( Abc_Ntk_t * pNtk, int fVerbose )
     for ( i = 0; i < p->nOutputs; i++ )
         for ( v = 0; v < p->nInputs; v++ )
             if ( Sim_SuppFunHasVar( p->vSuppFun, i, v ) )
-                Vec_VecPush( p->vSupports, i, (void *)(ABC_PTRUINT_T)v );
+                Vec_VecPushInt( p->vSupports, i, v );
     return p;
 }
 


### PR DESCRIPTION
A 32-bit integer is pushed as pointer, but later it is accessed as integer by other functions.
Note that a pointer is 64-bit in 64-bit machine.
For example: 
The array size will be twice larger than expected size.
If you push 1, 2, 3 to that array, then you will get 0,1,0,2,0,3.