### PR TITLE
Fix: header malloc.h is depreciated

### DIFF
--- a/src/base/main/mainReal.c
+++ b/src/base/main/mainReal.c
@@ -50,7 +50,7 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <sys/resource.h>
 #include <unistd.h>      
 #include <signal.h>      
-#include <malloc.h>      
+#include <stdlib.h>
 #endif
 
 #include "base/abc/abc.h"


### PR DESCRIPTION
I tried to compile ABC with gcc-8 (Homebrew GCC 8.2.0) 8.2.0 on macOS. And I encountered a fatal error.
```bash
src/base/main/mainReal.c:53:10: fatal error: malloc.h: No such file or directory
```
I think `malloc.h` is depreciated on many platforms and should be replaced with `stdlib.h`.