### PR TITLE
Fix(Abc_NtkDupObj): copy node's name as expected

### DIFF
--- a/src/base/abc/abcObj.c
+++ b/src/base/abc/abcObj.c
@@ -371,7 +371,11 @@ Abc_Obj_t * Abc_NtkDupObj( Abc_Ntk_t * pNtkNew, Abc_Obj_t * pObj, int fCopyName 
     // copy functionality/names
     if ( Abc_ObjIsNode(pObj) ) // copy the function if functionality is compatible
     {
-        if ( pNtkNew->ntkFunc == pObj->pNtk->ntkFunc ) 
+        if ( fCopyName )
+        {
+            Abc_ObjAssignName(pObjNew, Abc_ObjName(pObj), NULL);
+        }
+        if ( pNtkNew->ntkFunc == pObj->pNtk->ntkFunc )
         {
             if ( Abc_NtkIsStrash(pNtkNew) ) 
             {}


### PR DESCRIPTION
Function `Abc_NtkDupObj` did not copy the node's name to the new network when `fCopyName == true` even though the comment said "copy functionality/names". I found this issue when I was trying to use `Abc_NtkCreateMffc`. The new MFFC network's internal nodes' names were remapped instead of staying consistent with the original network.
