### PR TITLE
Fix(Abc_ObjFanoutId): add missing inline function

### DIFF
--- a/src/base/abc/abc.h
+++ b/src/base/abc/abc.h
@@ -368,6 +368,7 @@ static inline int         Abc_ObjFanoutNum( Abc_Obj_t * pObj )       { return pO
 static inline int         Abc_ObjFaninId( Abc_Obj_t * pObj, int i)   { return pObj->vFanins.pArray[i]; }
 static inline int         Abc_ObjFaninId0( Abc_Obj_t * pObj )        { return pObj->vFanins.pArray[0]; }
 static inline int         Abc_ObjFaninId1( Abc_Obj_t * pObj )        { return pObj->vFanins.pArray[1]; }
+static inline int         Abc_ObjFanoutId(Abc_Obj_t *pObj, int i)    { return pObj->vFanouts.pArray[i];}
 static inline int         Abc_ObjFanoutEdgeNum( Abc_Obj_t * pObj, Abc_Obj_t * pFanout )  { assert( Abc_NtkHasAig(pObj->pNtk) );  if ( Abc_ObjFaninId0(pFanout) == pObj->Id ) return 0; if ( Abc_ObjFaninId1(pFanout) == pObj->Id ) return 1; assert( 0 ); return -1;  }
 static inline Abc_Obj_t * Abc_ObjFanout( Abc_Obj_t * pObj, int i )   { return (Abc_Obj_t *)pObj->pNtk->vObjs->pArray[ pObj->vFanouts.pArray[i] ];  }
 static inline Abc_Obj_t * Abc_ObjFanout0( Abc_Obj_t * pObj )         { return (Abc_Obj_t *)pObj->pNtk->vObjs->pArray[ pObj->vFanouts.pArray[0] ];  }


### PR DESCRIPTION
In macro `Abc_ObjForEachFanoutId`:
```C
#define Abc_ObjForEachFanoutId( pObj, iFanout, i )                                                 \
    for ( i = 0; (i < Abc_ObjFanoutNum(pObj)) && (((iFanout) = Abc_ObjFanoutId(pObj, i)), 1); i++ )
```
Function `Abc_ObjFanoutId` has never been declared / defined. Therefore I add the missing inline function Abc_ObjFanoutId  in `abc.h`, following `Abc_ObjFaninId`.