### PR TITLE
Added missing `static`.

### DIFF
--- a/src/opt/dau/dauCanon.c
+++ b/src/opt/dau/dauCanon.c
@@ -302,7 +302,7 @@ void Abc_TtNormalizeSmallTruth(word * pTruth, int nVars)
     }
 }
 
-inline void Abc_TtVerifySmallTruth(word * pTruth, int nVars)
+static inline void Abc_TtVerifySmallTruth(word * pTruth, int nVars)
 {
 #ifndef NDEBUG
     if (nVars < 6) {


### PR DESCRIPTION
This PR fixes a linking issue (encountered with CMake):

Undefined symbols for architecture x86_64:
  "_Abc_TtVerifySmallTruth", referenced from:
      _Abc_TtCountOnesInCofs in libabc.a(dauCanon.c.o)
      _Abc_TtCountOnesInTruth in libabc.a(dauCanon.c.o)
      _Abc_TtCanonicizeAda in libabc.a(dauCanon.c.o)
      _Abc_TtCannonVerify in libabc.a(dauCanon.c.o)