### PR TITLE
Update sclBufSize.c

### DIFF
--- a/src/map/scl/sclBufSize.c
+++ b/src/map/scl/sclBufSize.c
@@ -406,7 +406,8 @@ void Abc_SclBufSize( Bus_Man_t * p, float Gain )
     Abc_NtkForEachObjReverse( p->pNtk, pObj, i )
     {
         if ( !((Abc_ObjIsNode(pObj) && Abc_ObjFaninNum(pObj) > 0) || (Abc_ObjIsCi(pObj) && p->pPiDrive)) )
-            continue;
+            if(!(Abc_ObjIsPi(pObj) && p->pPars->fBufPis) )
+                continue;
         if ( 2 * nObjsOld < Abc_NtkObjNumMax(p->pNtk) )
         {
             printf( "Buffering could not be completed because the gain value (%d) is too low.\n", p->pPars->GainRatio );


### PR DESCRIPTION
Fix PI Buffering, The Buffer command has an option -p which should enable buffering the primary inputs but when this flag is enabled the primary inputs are not buffered, the reason is that the flag argument is not taken into consideration in the buffering condition statement, so I just added it to the statement and I made sure that it works correctly