### PR TITLE
Makefile: break apart steps in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,10 @@ depend: $(DEP)
 
 clean:
 	@echo "$(MSG_PREFIX)\`\` Cleaning up..."
-	$(VERBOSE)rm -rvf $(PROG) lib$(PROG).a $(OBJ) $(GARBAGE) $(OBJ:.o=.d)
+	$(VERBOSE)rm -rvf $(PROG) lib$(PROG).a
+	$(VERBOSE)rm -rvf $(OBJ)
+	$(VERBOSE)rm -rvf $(GARBAGE)
+	$(VERBOSE)rm -rvf $(OBJ:.o=.d)
 
 tags:
 	etags `find . -type f -regex '.*\.\(c\|h\)'`


### PR DESCRIPTION
The `make clean` target consists of a single `rm` call that passes every
generated file, object file, and dependency directory.  This results in
a command line that's around 53,800 characters long.

On Linux, the maximum length of a command line is 131,072 or 262,144
characters, however on Windows the limit is 32,768.

The 53,800 character command simply fails to run on Windows, which is a
problem when the first command that gets run is `make clean`.

Break this target into steps, first removing the output files, then the
object files, then any generated garbage, and then the object depedency
directories.

This fixes `make clean` (and as a result yosys) on Windows.

Signed-off-by: Sean Cross <sean@xobs.io>