### PR TITLE
Allow changing the `ar` binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 CC   := gcc
 CXX  := g++
+AR   := ar
 LD   := $(CXX)
 
 MSG_PREFIX ?=
@@ -8,6 +9,7 @@ ABCSRC = .
 
 $(info $(MSG_PREFIX)Using CC=$(CC))
 $(info $(MSG_PREFIX)Using CXX=$(CXX))
+$(info $(MSG_PREFIX)Using AR=$(AR))
 $(info $(MSG_PREFIX)Using LD=$(LD))
 
 PROG := abc
@@ -215,8 +217,7 @@ $(PROG): $(OBJ)
 
 lib$(PROG).a: $(LIBOBJ)
 	@echo "$(MSG_PREFIX)\`\` Linking:" $(notdir $@)
-	$(VERBOSE)ar rv $@ $?
-	$(VERBOSE)ranlib $@
+	$(VERBOSE)$(AR) rsv $@ $?
 
 lib$(PROG).so: $(LIBOBJ)
 	@echo "$(MSG_PREFIX)\`\` Linking:" $(notdir $@)

--- a/src/aig/gia/giaDup.c
+++ b/src/aig/gia/giaDup.c
@@ -855,12 +855,12 @@ Gia_Man_t * Gia_ManDupPerm( Gia_Man_t * p, Vec_Int_t * vPiPerm )
 }
 Gia_Man_t * Gia_ManDupPermFlop( Gia_Man_t * p, Vec_Int_t * vFfPerm )
 {
-    Vec_Int_t * vPermInv;
+    //Vec_Int_t * vPermInv;
     Gia_Man_t * pNew;
     Gia_Obj_t * pObj;
     int i;
     assert( Vec_IntSize(vFfPerm) == Gia_ManRegNum(p) );
-    vPermInv = Vec_IntInvert( vFfPerm, -1 );
+    //vPermInv = Vec_IntInvert( vFfPerm, -1 );
     pNew = Gia_ManStart( Gia_ManObjNum(p) );
     pNew->pName = Abc_UtilStrsav( p->pName );
     pNew->pSpec = Abc_UtilStrsav( p->pSpec );
@@ -868,14 +868,16 @@ Gia_Man_t * Gia_ManDupPermFlop( Gia_Man_t * p, Vec_Int_t * vFfPerm )
     Gia_ManForEachPi( p, pObj, i )
         pObj->Value = Gia_ManAppendCi(pNew);
     Gia_ManForEachRo( p, pObj, i )
-        Gia_ManRo(p, Vec_IntEntry(vPermInv, i))->Value = Gia_ManAppendCi(pNew);
+        //Gia_ManRo(p, Vec_IntEntry(vPermInv, i))->Value = Gia_ManAppendCi(pNew);
+        Gia_ManRo(p, Vec_IntEntry(vFfPerm, i))->Value = Gia_ManAppendCi( pNew );
     Gia_ManForEachAnd( p, pObj, i )
         pObj->Value = Gia_ManAppendAnd( pNew, Gia_ObjFanin0Copy(pObj), Gia_ObjFanin1Copy(pObj) );
     Gia_ManForEachPo( p, pObj, i )
         pObj->Value = Gia_ManAppendCo( pNew, Gia_ObjFanin0Copy(pObj) );
     Gia_ManForEachRi( p, pObj, i )
-        pObj->Value = Gia_ManAppendCo( pNew, Gia_ObjFanin0Copy( Gia_ManRi(p, Vec_IntEntry(vPermInv, i)) ) );
-    Vec_IntFree( vPermInv );
+        //pObj->Value = Gia_ManAppendCo( pNew, Gia_ObjFanin0Copy( Gia_ManRi(p, Vec_IntEntry(vPermInv, i)) ) );
+        pObj->Value = Gia_ManAppendCo( pNew, Gia_ObjFanin0Copy( Gia_ManRi(p, Vec_IntEntry(vFfPerm, i)) ) );
+    //Vec_IntFree( vPermInv );
     Gia_ManSetRegNum( pNew, Gia_ManRegNum(p) );
     return pNew;
 }


### PR DESCRIPTION
This is useful for cross-compilation, when build `ar` cannot handle
the target object files.

The invocation of `ranlib` is replaced with `ar s`, which is
equivalent and simplifies the build system a bit.