### PR TITLE
Add giaDeep.c to module.make.

### DIFF
--- a/src/aig/gia/module.make
+++ b/src/aig/gia/module.make
@@ -16,6 +16,7 @@ SRC +=    src/aig/gia/giaAig.c \
     src/aig/gia/giaCSat2.c \
     src/aig/gia/giaCTas.c \
     src/aig/gia/giaCut.c \
+    src/aig/gia/giaDeep.c \
     src/aig/gia/giaDfs.c \
     src/aig/gia/giaDup.c \
     src/aig/gia/giaEdge.c \


### PR DESCRIPTION
This was left out when the file was added, which breaks the build on Unix.