### PR TITLE
Fix &trace, add "-w" option to print critical path

### DIFF
--- a/src/aig/gia/gia.h
+++ b/src/aig/gia/gia.h
@@ -1559,7 +1559,7 @@ extern int                 Gia_ManIncrSimCheckOver( Gia_Man_t * p, int iLit0, in
 extern int                 Gia_ManIncrSimCheckEqual( Gia_Man_t * p, int iLit0, int iLit1 );
 /*=== giaSpeedup.c ============================================================*/
 extern float               Gia_ManDelayTraceLut( Gia_Man_t * p );
-extern float               Gia_ManDelayTraceLutPrint( Gia_Man_t * p, int fVerbose );
+extern float               Gia_ManDelayTraceLutPrint( Gia_Man_t * p, int fVerbose, int fVerbosePath );
 extern Gia_Man_t *         Gia_ManSpeedup( Gia_Man_t * p, int Percentage, int Degree, int fVerbose, int fVeryVerbose );
 /*=== giaSplit.c ============================================================*/
 extern void                Gia_ManComputeOneWinStart( Gia_Man_t * p, int nAnds, int fReverse );

--- a/src/aig/gia/giaIf.c
+++ b/src/aig/gia/giaIf.c
@@ -2362,9 +2362,11 @@ Gia_Man_t * Gia_ManPerformMappingInt( Gia_Man_t * p, If_Par_t * pPars )
     // print delay trace
     if ( pPars->fVerboseTrace )
     {
+        Gia_ManTransferTiming( pNew, p );
         pNew->pLutLib = pPars->pLutLib;
-        Gia_ManDelayTraceLutPrint( pNew, 1 );
+        Gia_ManDelayTraceLutPrint( pNew, pPars->fVerbose );
         pNew->pLutLib = NULL;
+        Gia_ManTransferTiming( p, pNew );
     }
     return pNew;
 }

--- a/src/aig/gia/giaIf.c
+++ b/src/aig/gia/giaIf.c
@@ -2364,7 +2364,7 @@ Gia_Man_t * Gia_ManPerformMappingInt( Gia_Man_t * p, If_Par_t * pPars )
     {
         Gia_ManTransferTiming( pNew, p );
         pNew->pLutLib = pPars->pLutLib;
-        Gia_ManDelayTraceLutPrint( pNew, pPars->fVerbose );
+        Gia_ManDelayTraceLutPrint( pNew, 1, 0 );
         pNew->pLutLib = NULL;
         Gia_ManTransferTiming( p, pNew );
     }

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -40426,11 +40426,15 @@ int Abc_CommandAbc9Trace( Abc_Frame_t * pAbc, int argc, char ** argv )
     int c;
     int fUseLutLib;
     int fVerbose;
+    int fVerbosePath;
+    float WireDelay;
     // set defaults
     fUseLutLib = 0;
     fVerbose   = 0;
+    fVerbosePath = 0;
+    WireDelay  = 0;
     Extra_UtilGetoptReset();
-    while ( ( c = Extra_UtilGetopt( argc, argv, "lvh" ) ) != EOF )
+    while ( ( c = Extra_UtilGetopt( argc, argv, "lvhwW" ) ) != EOF )
     {
         switch ( c )
         {
@@ -40440,6 +40444,20 @@ int Abc_CommandAbc9Trace( Abc_Frame_t * pAbc, int argc, char ** argv )
         case 'v':
             fVerbose ^= 1;
             break;
+        case 'w':
+            fVerbosePath ^= 1;
+            break;
+        case 'W':
+            if ( globalUtilOptind >= argc )
+            {
+                Abc_Print( -1, "Command line switch \"-W\" should be followed by a floating point number.\n" );
+                goto usage;
+            }
+            WireDelay = (float)atof(argv[globalUtilOptind]);
+            globalUtilOptind++;
+            if ( WireDelay < 0.0 )
+                goto usage;
+            break;
         case 'h':
             goto usage;
         default:
@@ -40448,23 +40466,42 @@ int Abc_CommandAbc9Trace( Abc_Frame_t * pAbc, int argc, char ** argv )
     }
     if ( pAbc->pGia == NULL )
     {
-        Abc_Print( -1, "Abc_CommandAbc9Speedup(): There is no AIG to map.\n" );
+        Abc_Print( -1, "Abc_CommandAbc9Trace(): There is no AIG to map.\n" );
         return 1;
     }
     if ( !Gia_ManHasMapping(pAbc->pGia) )
     {
-        Abc_Print( -1, "Abc_CommandAbc9Speedup(): Mapping of the AIG is not defined.\n" );
+        Abc_Print( -1, "Abc_CommandAbc9Trace(): Mapping of the AIG is not defined.\n" );
         return 1;
     }
     pAbc->pGia->pLutLib = fUseLutLib ? pAbc->pLibLut : NULL;
-    Gia_ManDelayTraceLutPrint( pAbc->pGia, fVerbose );
+    If_LibLut_t * pLutLib = pAbc->pGia->pLutLib;
+    // add wire delay to LUT library delays
+    if ( pLutLib && WireDelay > 0 )
+    {
+        int i, k;
+        for ( i = 0; i <= pLutLib->LutMax; i++ )
+            for ( k = 0; k <= i; k++ )
+                pLutLib->pLutDelays[i][k] += WireDelay;
+    }
+    Gia_ManDelayTraceLutPrint( pAbc->pGia, fVerbose, fVerbosePath );
+    // subtract wire delay from LUT library delays
+    if ( pLutLib && WireDelay > 0 )
+    {
+        int i, k;
+        for ( i = 0; i <= pLutLib->LutMax; i++ )
+            for ( k = 0; k <= i; k++ )
+                pLutLib->pLutDelays[i][k] -= WireDelay;
+    }
     return 0;
 
 usage:
     Abc_Print( -2, "usage: &trace [-lvh]\n" );
     Abc_Print( -2, "\t           performs delay trace of LUT-mapped network\n" );
+    Abc_Print( -2, "\t-W float : sets wire delay between adjects LUTs [default = %f]\n", WireDelay );
     Abc_Print( -2, "\t-l       : toggle using unit- or LUT-library-delay model [default = %s]\n", fUseLutLib? "lib": "unit" );
-    Abc_Print( -2, "\t-v       : toggle printing optimization summary [default = %s]\n", fVerbose? "yes": "no" );
+    Abc_Print( -2, "\t-v       : toggle printing slack summary [default = %s]\n", fVerbose? "yes": "no" );
+    Abc_Print( -2, "\t-w       : toggle printing critical path [default = %s]\n", fVerbosePath? "yes": "no" );
     Abc_Print( -2, "\t-h       : print the command usage\n");
     return 1;
 }


### PR DESCRIPTION
Example output:

```
abc - > &if -v -W 250;
K = 8. Memory (bytes): Truth =    0. Cut =   64. Obj =  144. Set =  672. CutMin = no
Node =    4304.  Ch =     0.  Total mem =    1.35 MB. Peak cut mem =    0.16 MB.
P:  Del = 3455.00.  Ar =    4989.0.  Edge =     5555.  Cut =    52962.  T =     0.01 sec
P:  Del = 3416.00.  Ar =    4689.0.  Edge =     5715.  Cut =    52102.  T =     0.01 sec
P:  Del = 3416.00.  Ar =    3409.0.  Edge =     4705.  Cut =    61617.  T =     0.01 sec
E:  Del = 3416.00.  Ar =    3372.0.  Edge =     4641.  Cut =    61617.  T =     0.00 sec
F:  Del = 3416.00.  Ar =    3278.0.  Edge =     4607.  Cut =    60112.  T =     0.01 sec
E:  Del = 3416.00.  Ar =    3274.0.  Edge =     4602.  Cut =    60112.  T =     0.00 sec
A:  Del = 3416.00.  Ar =    3244.0.  Edge =     4401.  Cut =    61874.  T =     0.02 sec
E:  Del = 3416.00.  Ar =    3242.0.  Edge =     4399.  Cut =    61874.  T =     0.00 sec
A:  Del = 3416.00.  Ar =    3242.0.  Edge =     4398.  Cut =    61392.  T =     0.02 sec
E:  Del = 3416.00.  Ar =    3242.0.  Edge =     4398.  Cut =    61392.  T =     0.00 sec
Total time =     0.10 sec
abc - > &trace -l -W 250 -w;
Max delay = 3416.00. Delay trace using LUT library model:
 3416.00  PO
 2701.00  LUT  (K = 8)
 2213.00  LUT  (K = 6)
 1900.00  BOX  num    95 (CARRY4)
 1786.00  BOX  num    94 (CARRY4)
 1260.00  BOX  num    93 (CARRY4)
  791.00  BOX  num    80 (CARRY4)
  303.00  LUT  (K = 2)
  303.00  PI
```

Note that `&trace` is not currently aware of muxes (produced by `&if -i`) nor LUT structures (`&if -S NN`)