### PR TITLE
Fix verilog file parsing error

### DIFF
--- a/src/base/ver/verCore.c
+++ b/src/base/ver/verCore.c
@@ -1340,6 +1340,7 @@ int Ver_ParseGateStandard( Ver_Man_t * pMan, Abc_Ntk_t * pNtk, Ver_GateType_t Ga
     Ver_StreamMove( p );
 
     // this is gate name - throw it away
+    Ver_ParseGetName( pMan );
     if ( Ver_StreamPopChar(p) != '(' )
     {
         sprintf( pMan->sError, "Cannot parse a standard gate (expected opening parenthesis)." );
@@ -1436,6 +1437,7 @@ int Ver_ParseFlopStandard( Ver_Man_t * pMan, Abc_Ntk_t * pNtk )
         return 0;
 
     // this is gate name - throw it away
+    Ver_ParseGetName( pMan );
     if ( Ver_StreamPopChar(p) != '(' )
     {
         sprintf( pMan->sError, "Cannot parse a standard gate (expected opening parenthesis)." );
@@ -1573,6 +1575,7 @@ int Ver_ParseGate( Ver_Man_t * pMan, Abc_Ntk_t * pNtk, Mio_Gate_t * pGate )
     if ( pWord == NULL )
         return 0;
     // this is gate name - throw it away
+    Ver_ParseGetName( pMan );
     if ( Ver_StreamPopChar(p) != '(' )
     {
         sprintf( pMan->sError, "Cannot parse gate %s (expected opening parenthesis).", Mio_GateReadName(pGate) );


### PR DESCRIPTION
When the parser encounters a gate name, it will not skip this name but throws an error of `expected opening parenthesis`.
For example, the following verilog file will cause this error:
```v
module top(x1, x2, z);
    input x1, x2;
    output z;
    and aaa(z, x1, x2); // Error due to the gate name "aaa"
endmodule
```

I fixed this bug by simply calling the `Ver_ParseGetName` function to skip the gate name.