### PR TITLE
Skip the body of Gia_LutForEachFanin if iFan is negative.

### DIFF
--- a/src/aig/gia/gia.h
+++ b/src/aig/gia/gia.h
@@ -1117,7 +1117,7 @@ static inline int         Gia_ObjCellId( Gia_Man_t * p, int iLit )          { re
 #define Gia_ManForEachLutReverse( p, i )                                \
     for ( i = Gia_ManObjNum(p) - 1; i > 0; i-- ) if ( !Gia_ObjIsLut(p, i) ) {} else
 #define Gia_LutForEachFanin( p, i, iFan, k )                            \
-    for ( k = 0; k < Gia_ObjLutSize(p,i) && ((iFan = Gia_ObjLutFanins(p,i)[k]),1); k++ )
+    for ( k = 0; k < Gia_ObjLutSize(p,i) && ((iFan = Gia_ObjLutFanins(p,i)[k]),1); k++ ) if (iFan >= 0)
 #define Gia_LutForEachFaninObj( p, i, pFanin, k )                       \
     for ( k = 0; k < Gia_ObjLutSize(p,i) && ((pFanin = Gia_ManObj(p, Gia_ObjLutFanins(p,i)[k])),1); k++ )
 


### PR DESCRIPTION
This commit fixes https://github.com/berkeley-abc/abc/issues/84.  The invalid memory accesses when iFan == -1 must have somehow led to the eventual memory corruption.  With this change, I get a valid run with the example provided in that issue.
