### PR TITLE
Fix putontop command

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -10423,8 +10423,10 @@ int Abc_CommandPutOnTop( Abc_Frame_t * pAbc, int argc, char ** argv )
     }
 
     // get the new network
-    pNtkRes = Abc_NtkPutOnTop( pNtk, pNtk2 );
+    Abc_Ntk_t *pNtk2Logic = Abc_NtkToLogic( pNtk2 );
+    pNtkRes = Abc_NtkPutOnTop( pNtk, pNtk2Logic );
     Abc_NtkDelete( pNtk2 );
+    Abc_NtkDelete( pNtk2Logic );
     // replace the current network
     Abc_FrameReplaceCurrentNetwork( pAbc, pNtkRes );
     return 0;


### PR DESCRIPTION
The `putontop` command is broken because it automatically fails an assertion about the network type. To fix it, the network passed to the command is converted to a logic network.

Here is an example demonstrating the bug:

```
$ abc
UC Berkeley, ABC 1.01 (compiled Jun 24 2020 14:50:41)
abc 01> read bottom.aig
abc 02> logic
abc 03> putontop top.aig
Assertion failed: (Abc_NtkIsLogic(pNtk2)), function Abc_NtkPutOnTop, file src/base/abci/abcStrash.c, line 798.
Abort trap: 6
```
[top_bottom.zip](https://github.com/berkeley-abc/abc/files/4906885/top_bottom.zip)

