### PR TITLE
Build successfully with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,10 @@ CFLAGS += -Wno-unused-but-set-variable
 endif
 else
 $(info $(MSG_PREFIX)Found GCC_MAJOR>=5)
+CLANG_HEADER=$(shell $(CC) --version | grep -w clang)
+ifeq (,$(CLANG_HEADER))
 CFLAGS += -Wno-unused-but-set-variable
+endif
 endif
 endif
 

--- a/src/base/io/io.c
+++ b/src/base/io/io.c
@@ -18,6 +18,7 @@
 
 ***********************************************************************/
 
+#include <unistd.h>
 #include "ioAbc.h"
 #include "base/main/mainInt.h"
 #include "aig/saig/saig.h"


### PR DESCRIPTION
This is for ABC source code to build successfully by clang compiler. There are two issues.
1.

> src/base/io/io.c:1470:5: error: implicit declaration of function 'unlink' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
    unlink( pFileTemp );
    ^

The solution is to include a header
```c
#include <unistd.h>
```

2. There is a warning for each file

> warning: unknown warning option '-Wno-unused-but-set-variable'; did you mean
      '-Wno-unused-const-variable'? [-Wunknown-warning-option]

The solution is to detect clang and do not add -Wno-unused-but-set-variable for clang in Makefile
