### PR TITLE
Make depends.sh (s)ccache-aware.

### DIFF
--- a/depends.sh
+++ b/depends.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 #echo "## Got: $*"
-CC="$1"
-DIR="$2"
-shift 2
+if [ $1="ccache" -o $1="sccache" ]; then
+    CC="$1 $2"
+    DIR="$3"
+    shift 3
+else
+    CC="$1"
+    DIR="$2"
+    shift 2
+fi
 case "$DIR" in
     "" | ".")
     $CC -MM -MG "$@" | sed -e 's@^\(.*\)\.o:@\1.d \1.o:@'


### PR DESCRIPTION
Attempting to use (s)ccache to build `abc` with a Makefile-based build results in numerous errors like the following (this is [sccache](https://github.com/mozilla/sccache) acting as a ccache replacement):

```
HEAD is now at 341db256 Merge pull request #6 from whitequark/wasi-signal
[  5%] ABC: Using CC=ccache gcc
[  5%] ABC: Using CXX=ccache gcc
[  5%] ABC: Using AR=ar
[  5%] ABC: Using LD=ccache gcc
[  5%] ABC: Compiling with CUDD
[  5%] ABC: Using libreadline
[  5%] ABC: Using pthreads
[  5%] ABC: Found GCC_VERSION 5.4.0
[  5%] ABC: Found GCC_MAJOR>=5
[  5%] ABC: Using explicit -lstdc++
[  5%] ABC: Using CFLAGS=-Wall -Wno-unused-function -Wno-write-strings -Wno-sign-compare -DABC_USE_STDINT_H -DABC_USE_CUDD=1 -DABC_USE_READLINE  -DABC_USE_PTHREADS -Wno-unused-but-set-variable
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb4Sweep.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb4Nonlin.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb4Image.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb4Cex.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb3Nonlin.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb3Image.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb2Image.c
[  5%] ABC: `` Generating dependency: /src/bdd/llb/llb2Flow.c
error: Found argument '-M' which wasn't expected, or isn't valid in this context

USAGE:
    ccache [FLAGS] [OPTIONS] [cmd]...

For more information try --help
error: Found argument '-M' which wasn't expected, or isn't valid in this context

USAGE:
    ccache [FLAGS] [OPTIONS] [cmd]...
```

These errors don't actually fail the build but cause dependency info to not be generated properly. I figured out that this is because `depends.sh` unconditionally only uses the first argument as the compiler driver.

I added a special case for (s)ccache to `depends.sh` so that (s)ccache logic works properly and dependencies are generated. I added both because while `sccache` is nominally a `ccache` replacement, I've run into edge cases where it will not work properly when invoked as `ccache`. I would appreciate feedback as to whether this special-casing is acceptable.