### PR TITLE
Added cell ignore list for read_lib command

### DIFF
--- a/src/map/scl/sclLib.h
+++ b/src/map/scl/sclLib.h
@@ -734,7 +734,7 @@ static inline void Scl_LibHandleInputDriver2( SC_Cell * pCell, SC_PairI * pLoadI
 }
 
 /*=== sclLiberty.c ===============================================================*/
-extern SC_Lib *      Abc_SclReadLiberty( char * pFileName, int fVerbose, int fVeryVerbose );
+extern SC_Lib *      Abc_SclReadLiberty( char * pFileName, char ** pIgnoreList, int fVerbose, int fVeryVerbose );
 /*=== sclLibScl.c ===============================================================*/
 extern SC_Lib *      Abc_SclReadFromGenlib( void * pLib );
 extern SC_Lib *      Abc_SclReadFromStr( Vec_Str_t * vOut );

--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -1427,7 +1427,7 @@ Vec_Ptr_t * Scl_LibertyReadTemplates( Scl_Tree_t * p )
 //    Scl_LibertyPrintTemplates( vRes );
     return vRes;
 }
-Vec_Str_t * Scl_LibertyReadSclStr( Scl_Tree_t * p, int fVerbose, int fVeryVerbose )
+Vec_Str_t * Scl_LibertyReadSclStr( Scl_Tree_t * p, char ** pIgnoreList, int fVerbose, int fVeryVerbose )
 {
     int fUseFirstTable = 0;
     Vec_Str_t * vOut;
@@ -1673,7 +1673,7 @@ Vec_Str_t * Scl_LibertyReadSclStr( Scl_Tree_t * p, int fVerbose, int fVeryVerbos
     }
     return vOut;
 }
-SC_Lib * Abc_SclReadLiberty( char * pFileName, int fVerbose, int fVeryVerbose )
+SC_Lib * Abc_SclReadLiberty( char * pFileName, char ** pIgnoreList, int fVerbose, int fVeryVerbose )
 {
     SC_Lib * pLib;
     Scl_Tree_t * p;
@@ -1683,7 +1683,7 @@ SC_Lib * Abc_SclReadLiberty( char * pFileName, int fVerbose, int fVeryVerbose )
         return NULL;
 //    Scl_LibertyParseDump( p, "temp_.lib" );
     // collect relevant data
-    vStr = Scl_LibertyReadSclStr( p, fVerbose, fVeryVerbose );
+    vStr = Scl_LibertyReadSclStr( p, pIgnoreList, fVerbose, fVeryVerbose );
     Scl_LibertyStop( p, fVeryVerbose );
     if ( vStr == NULL )
         return NULL;
@@ -1721,7 +1721,7 @@ void Scl_LibertyTest()
     if ( p == NULL )
         return;
 //    Scl_LibertyParseDump( p, "temp_.lib" );
-    vStr = Scl_LibertyReadSclStr( p, fVerbose, fVeryVerbose );
+    vStr = Scl_LibertyReadSclStr( p, NULL, fVerbose, fVeryVerbose );
     Scl_LibertyStringDump( "test_scl.lib", vStr );
     Vec_StrFree( vStr );
     Scl_LibertyStop( p, fVerbose );

--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -694,6 +694,28 @@ int Scl_LibertyReadCellOutputNum( Scl_Tree_t * p, Scl_Item_t * pCell )
 
 /**Function*************************************************************
 
+  Synopsis    [Checks if the cell name is included in the ignore list.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Scl_LibertyIsOnIgnoreList( Scl_Tree_t * p, Scl_Item_t * pCell, char ** pIgnoreList )
+{
+    while ( *pIgnoreList != NULL )
+    {
+        if ( Scl_LibertyCompare( p, pCell->Head, *pIgnoreList ) )
+            return 1;
+        pIgnoreList++;
+    }
+    return 0;
+}
+
+/**Function*************************************************************
+
   Synopsis    [Parses the standard cell library in Liberty format.]
 
   Description [Writes the resulting file in Genlib format.]
@@ -1464,6 +1486,12 @@ Vec_Str_t * Scl_LibertyReadSclStr( Scl_Tree_t * p, char ** pIgnoreList, int fVer
     nCells = 0;
     Scl_ItemForEachChildName( p, Scl_LibertyRoot(p), pCell, "cell" )
     {
+        if ( Scl_LibertyIsOnIgnoreList(p, pCell, pIgnoreList) )
+        {
+            if ( fVeryVerbose )  printf( "Scl_LibertyReadGenlib() skipped cell \"%s\" due to being on the ignore list.\n", Scl_LibertyReadString(p, pCell->Head) );
+            nSkipped[3]++;
+            continue;
+        }
         if ( Scl_LibertyReadCellIsFlop(p, pCell) )
         {
             if ( fVeryVerbose )  printf( "Scl_LibertyReadGenlib() skipped sequential cell \"%s\".\n", Scl_LibertyReadString(p, pCell->Head) );
@@ -1496,6 +1524,8 @@ Vec_Str_t * Scl_LibertyReadSclStr( Scl_Tree_t * p, char ** pIgnoreList, int fVer
     Vec_StrPut_( vOut );
     Scl_ItemForEachChildName( p, Scl_LibertyRoot(p), pCell, "cell" )
     {
+        if ( Scl_LibertyIsOnIgnoreList(p, pCell, pIgnoreList) )
+            continue;
         if ( Scl_LibertyReadCellIsFlop(p, pCell) )
             continue;
         if ( Scl_LibertyReadCellIsDontUse(p, pCell) )

--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -705,9 +705,11 @@ int Scl_LibertyReadCellOutputNum( Scl_Tree_t * p, Scl_Item_t * pCell )
 ***********************************************************************/
 int Scl_LibertyIsOnIgnoreList( Scl_Tree_t * p, Scl_Item_t * pCell, char ** pIgnoreList )
 {
+	if ( pIgnoreList == NULL )
+		return 0;
     while ( *pIgnoreList != NULL )
     {
-        if ( Scl_LibertyCompare( p, pCell->Head, *pIgnoreList ) )
+        if ( !Scl_LibertyCompare( p, pCell->Head, *pIgnoreList ) )
             return 1;
         pIgnoreList++;
     }


### PR DESCRIPTION
This merge requests implements an explicit ignore list with the `-I` switch for the read_lib command.
The cell names are passed as slash-separated list and are passed to the import function as an additional exclude constraint.

With this feature cells from the imported cell library can be explicitly ignored without the need for modification of the cell library.
This eliminates the need for having multiple variants of the same cell library stored on disk when varying the enabled cells.
This change is mostly intended for academic purposes where different variants of the same cell library are tested in parallel.

As this is my first contribution to this project feedback / improvements about the code style or the implementation would be great to hear.