### PR TITLE
Fix name-mangling behavior of inv_get

### DIFF
--- a/src/base/wlc/wlcAbc.c
+++ b/src/base/wlc/wlcAbc.c
@@ -140,7 +140,7 @@ void Wlc_NtkPrintInvStats( Wlc_Ntk_t * pNtk, Vec_Int_t * vCounts, int fVerbose )
   SeeAlso     []
 
 ***********************************************************************/
-Abc_Ntk_t * Wlc_NtkGetInv( Wlc_Ntk_t * pNtk, Vec_Int_t * vInv )
+Abc_Ntk_t * Wlc_NtkGetInv( Wlc_Ntk_t * pNtk, Vec_Int_t * vInv, Vec_Ptr_t * vNamesIn )
 {
     extern Vec_Int_t * Pdr_InvCounts( Vec_Int_t * vInv );
     extern Vec_Str_t * Pdr_InvPrintStr( Vec_Int_t * vInv, Vec_Int_t * vCounts );
@@ -166,8 +166,14 @@ Abc_Ntk_t * Wlc_NtkGetInv( Wlc_Ntk_t * pNtk, Vec_Int_t * vInv )
             if ( Entry == 0 )
                 continue;
             pMainObj = Abc_NtkCreatePi( pMainNtk );
-            sprintf( Buffer, "pi%d", i );
-            Abc_ObjAssignName( pMainObj, Buffer, NULL );
+            if (vNamesIn != NULL && i < Vec_PtrSize(vNamesIn)) {
+                Abc_ObjAssignName( pMainObj, (char *)Vec_PtrEntry(vNamesIn, i), NULL );
+            }
+            else
+            {
+                sprintf( Buffer, "pi%d", i );
+                Abc_ObjAssignName( pMainObj, Buffer, NULL );
+            }
         }
         if ( Abc_NtkPiNum(pMainNtk) != nInputs )
         {

--- a/src/base/wlc/wlcAbc.c
+++ b/src/base/wlc/wlcAbc.c
@@ -166,6 +166,8 @@ Abc_Ntk_t * Wlc_NtkGetInv( Wlc_Ntk_t * pNtk, Vec_Int_t * vInv, Vec_Ptr_t * vName
             if ( Entry == 0 )
                 continue;
             pMainObj = Abc_NtkCreatePi( pMainNtk );
+            // If vNamesIn is given, take names from there for as many entries as possible
+            // otherwise generate names from counter
             if (vNamesIn != NULL && i < Vec_PtrSize(vNamesIn)) {
                 Abc_ObjAssignName( pMainObj, (char *)Vec_PtrEntry(vNamesIn, i), NULL );
             }

--- a/src/base/wlc/wlcCom.c
+++ b/src/base/wlc/wlcCom.c
@@ -1784,7 +1784,7 @@ int Abc_CommandInvGet( Abc_Frame_t * pAbc, int argc, char ** argv )
 usage:
     Abc_Print( -2, "usage: inv_get [-fvh]\n" );
     Abc_Print( -2, "\t         places invariant found by PDR as the current network in the main-space\n" );
-    Abc_Print( -2, "\t         (in the case of \'sat\' or \'undecided\', inifity clauses are used)\n" );
+    Abc_Print( -2, "\t         (in the case of \'sat\' or \'undecided\', infinity clauses are used)\n" );
     Abc_Print( -2, "\t-f     : toggle reading flop names from the &-space [default = %s]\n", fFlopNamesFromGia? "yes": "no" );
     Abc_Print( -2, "\t-v     : toggle printing verbose information [default = %s]\n", fVerbose? "yes": "no" );
     Abc_Print( -2, "\t-h     : print the command usage\n");


### PR DESCRIPTION
## Synopsis
When generating an inductive invariant via "pdr -d", the dumped PLA file will contain the correct flop names and will thus work. However, when we load the invariant with "inv_get", e.g., to minimize it with "inv_min", and then dump it manually using "write_pla", then all flop names will be lost and replaced by signal names of the pattern "pi#", with # being a number counting the flops.

## Minimal example
Consider a simple BLIF example
```BLIF
.model simplecount
.inputs clock enable
.outputs error
.latch      x0n x0  0
.latch      x1n x1  0
.latch      x2n x2  0
.latch      x3n x3  0
.latch      x4n x4  0
.latch      x5n x5  0
.latch      errmon errcond  0
.names enable x0 x0n
10 1
.names x1 x0 x1n
01 1
10 1
.names x2 x1 x0 x2n
011 1
100 1
101 1
110 1
.names x3 x2 x1 x0 x3n
0111 1
1000 1
1001 1
1010 1
1011 1
1100 1
1101 1
1110 1
.names x3 x4n
1 1
.names x4 x5n
1 1
.names x5 notx5
0 1
.names x5 notx5 errmon
11 1
.names errcond error
1 1
.end
```
and run
```bash
./abc -c "read_blif simplecount.blif; undc; strash; zero; pdr -v; inv_get; print_stats; write_pla simplecount_inv.pla"
```
Then `simplecount_inv.pla` will use "pi6" instead of "errcond". Hence validating this invariant will also fail later:
```bash
./abc -c "read_blif simplecount.blif; undc; strash; zero; print_stats; &get -mnv; read_pla simplecount_inv.pla; inv_put; inv_print; inv_check -v"
ABC command line: "read_blif simplecount.blif ; print_stats; undc; strash; zero; print_stats; &get -mnv; read_pla simplecount_inv.pla; inv_put; inv_print; inv_check -v".

simplecount                   : i/o =    2/    1  lat =    7  and =     19  lev =  6
Cannot read input name "pi6" of fanin 0.
Cannot read names for 1 inputs of the invariant.
Invariant contains 1 clauses with 1 literals and 1 flops (out of 7).
Coverage check failed for output 0.
Inductiveness check failed for clause 0.
Invariant verification failed for 2 clauses (out of 1). Time =     0.00 sec
```

## Expected behavior
Running the sequences
```bash
./abc -c "read_blif simplecount.blif; undc; strash; zero; pdr -v; inv_get; print_stats; write_pla simplecount_inv.pla"
./abc -c "read_blif simplecount.blif; undc; strash; zero; print_stats; &get -mnv; read_pla simplecount_inv.pla; inv_put; inv_print; inv_check -v"
```
ABC should be able to successfully verify the invariant it generates.

## Analysis
Although working with invariants (inv_put, inv_min) requires the user to put the main design into the &-space (&get), inv_get seems to be internally tailored towards working in tandem with word-level commands (%...). In particular, the flop names are NOT read from the design in the &-space but rather from the %-space (for lack of a better term), since inv_get retrieves the "main" network via Wlc_AbcGetNtk(pAbc). The subsequently called Wlc_NtkGetInv will thus run with (pNtk == NULL) in the example above and hence assign new names via
```C
sprintf( Buffer, "pi%d", i );
```
This behavior breaks the work flow from the example above, since the invariant network put into the main space by inv_get will already have mangled names. You can see this by just getting and immediately putting the invariant back again, which will already fail:
```bash
./abc -c "read_blif simplecount.blif; undc; strash; zero; pdr -v; &get -mnv; inv_get -v; inv_put -v; inv_check -v"
```

## Proposed changes
Since inv_put and inv_min both require the user to put the design into the &-space, it would make much sense for inv_get to be able to also work with designs stored there in order to obtain the names required to build a valid invariant. In order to not break existing behavior, I propose to implement this functionality via a new switch that tells inv_get to look for the flop names in the &-space (i.e., the current GIA). Internally I propose to augment Wlc_NtkGetInv with an optional new parameter ( Vec_Ptr_t * ) vNamesIn that may be either NULL (old behavior) or contain a list of names to use for the flops for maximum flexibility. If not enough names are provided, we just revert to the current name generation behavior for the remaining flops.

## Result
By replacing "inv_get" with "&get -mnv; inv_get -f" the proposed changes will result in the expected behavior in the above examples:
```bash
./abc -c "read_blif simplecount.blif; undc; strash; zero; pdr -v; &get -mnv; inv_get -f; inv_put -v; inv_check -v"
```
The changes add new functionality that is only invoked via a new command switch and therefore do not interfere with existing behavior. The changed project compiles and links from scratch, thus showing that the changed signature of Wlc_NtkGetInv does not break code in other places of the project.