### PR TITLE
Consider unconnected carry-out ports

### DIFF
--- a/src/aig/gia/giaSweep.c
+++ b/src/aig/gia/giaSweep.c
@@ -389,7 +389,7 @@ Vec_Int_t * Gia_ManComputeCarryOuts( Gia_Man_t * p )
     int i, iLast, iBox, nBoxes =  Tim_ManBoxNum( pManTime );
     Vec_Int_t * vCarryOuts = Vec_IntAlloc( nBoxes );
 
-    // Create and populare reference count (and free later) only if not already
+    // Create and populate reference count (and free later) only if not already
     // done.
     int createRefs = (p->pRefs == NULL);
     if (createRefs) {

--- a/src/aig/gia/giaSweep.c
+++ b/src/aig/gia/giaSweep.c
@@ -388,6 +388,14 @@ Vec_Int_t * Gia_ManComputeCarryOuts( Gia_Man_t * p )
     Tim_Man_t * pManTime = (Tim_Man_t *)p->pManTime;
     int i, iLast, iBox, nBoxes =  Tim_ManBoxNum( pManTime );
     Vec_Int_t * vCarryOuts = Vec_IntAlloc( nBoxes );
+
+    // Create and populare reference count (and free later) only if not already
+    // done.
+    int createRefs = (p->pRefs == NULL);
+    if (createRefs) {
+        Gia_ManCreateRefs( p );
+    }
+
     for ( i = 0; i < nBoxes; i++ )
     {
         iLast = Tim_ManBoxInputLast( pManTime, i );
@@ -398,9 +406,24 @@ Vec_Int_t * Gia_ManComputeCarryOuts( Gia_Man_t * p )
         if ( iBox == -1 ) 
             continue;
         assert( Gia_ObjIsCi(pObj) );
-        if ( Gia_ObjCioId(pObj) == Tim_ManBoxOutputLast(pManTime, iBox) )
+        if ( Gia_ObjCioId(pObj) == Tim_ManBoxOutputLast(pManTime, iBox) ) {
             Vec_IntPush( vCarryOuts, Gia_ObjId(p, pObj) );
+
+            // We have identified a carry connection. Check if the carry out
+            // of the destination box is unconnected. If so then add it to
+            // the carry list as well.
+            iLast = Tim_ManBoxOutputLast(pManTime, i);
+            pObj = Gia_ManCi(p, iLast);
+            if ( Gia_ObjRefNum(p, pObj) == 0 ) {
+                Vec_IntPush( vCarryOuts, Gia_ObjId(p, pObj) );
+            }
+        }
     }
+
+    if (createRefs) {
+        ABC_FREE( p->pRefs );
+    }
+
     return vCarryOuts;
 }
 


### PR DESCRIPTION
In rare cases it has been observed that in `ABC9` after the `&sweep` command some previously unconnected carry-outs got connected to some logic. This obviously isn't correct.

During debugging I've noticed that the logic which detects carry connections considers only carry-out to carry-in connections. It does not consider any unconnected carry-outs. This may lead to the observed incorrect behavior.

The change included with this PR identifies and adds all carry-out port nodes even if they are unconnected. This appears to solve the issue.

I'm looking forward to feedback whether the proposed solution is correct and how it could be improved.