### PR TITLE
Typos identified by lintian

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -35199,7 +35199,7 @@ usage:
     Abc_Print( -2, "usage: &extract [-K <num>] [-vh]\n");
     Abc_Print( -2, "\t           extract shared logic for XOR-rich circuits\n");
     Abc_Print( -2, "\t-K <num> : the minimum gate size to consider for extraction [default = %d]\n", nMultiSize );
-    Abc_Print( -2, "\t-a       : toogle extracting ANDs instead of XORs [default = %s]\n", fAnds? "yes": "no" );
+    Abc_Print( -2, "\t-a       : toggle extracting ANDs instead of XORs [default = %s]\n", fAnds? "yes": "no" );
     Abc_Print( -2, "\t-v       : print verbose information [default = %s]\n", fVerbose? "yes": "no" );
     Abc_Print( -2, "\t-h       : print the command usage\n");
     return 1;
@@ -49492,7 +49492,7 @@ usage:
     Abc_Print( -2, "usage: &cfs [-LNURPrcdvh]\n" );
     Abc_Print( -2, "\t          performs simulation\n" );
     Abc_Print( -2, "\t-L num  : the limit on the number of occurrences [default = %d]\n",  Limit );
-    Abc_Print( -2, "\t-N num  : the number of repetions of each pattern [default = %d]\n", Reps );
+    Abc_Print( -2, "\t-N num  : the number of repetitions of each pattern [default = %d]\n", Reps );
     Abc_Print( -2, "\t-U num  : what to do with unseen patterns [default = %d]\n",         UnseenUse );
     Abc_Print( -2, "\t-R num  : what to do with rare patterns [default = %d]\n",           RareUse );
     Abc_Print( -2, "\t-P num  : base2-log of ramdom flip probability [default = %f]\n",    FlipProb );

--- a/src/bdd/cudd/cuddDecomp.c
+++ b/src/bdd/cudd/cuddDecomp.c
@@ -1673,7 +1673,7 @@ ZeroCase(
   constant. At the decomposition point, the factors returned are (f,
   1). Recur on the two children. The order is determined by the
   heavier branch. Combine the factors of the two children and pick the
-  one that already occurs in the gh table. Occurence in g is indicated
+  one that already occurs in the gh table. Occurrence in g is indicated
   by value 1, occurence in h by 2, occurence in both 3.]
 
   SideEffects []

--- a/src/opt/rwr/rwrExp.c
+++ b/src/opt/rwr/rwrExp.c
@@ -136,11 +136,11 @@ void Rwt_Man4ExplorePrint()
         pReprs[ s_pManRwrExp4->pnCounts[i] ] = i;
     }
 
-    printf( "Occurence = %6d.  Num classes = %4d.  \n", 0, 2288-nClasses );
+    printf( "Occurrence = %6d.  Num classes = %4d.  \n", 0, 2288-nClasses );
     for ( i = 1; i <= CountMax; i++ )
         if ( pDistrib[i] )
         {
-            printf( "Occurence = %6d.  Num classes = %4d.  Repr = ", i, pDistrib[i] );
+            printf( "Occurrence = %6d.  Num classes = %4d.  Repr = ", i, pDistrib[i] );
             Extra_PrintBinary( stdout, (unsigned*)&(pReprs[i]), 16 ); 
             printf( "\n" );
         }
@@ -256,7 +256,7 @@ void Rwt_Man5ExplorePrint()
     for ( i = 1; i <= CountMax; i++ )
         if ( pDistrib[i] )
         {
-            printf( "Occurence = %6d.  Num classes = %4d.  Repr = ", i, pDistrib[i] );
+            printf( "Occurrence = %6d.  Num classes = %4d.  Repr = ", i, pDistrib[i] );
             Extra_PrintBinary( stdout, pReprs + i, 32 ); 
             printf( "\n" );
         }


### PR DESCRIPTION
The Debian packaging has the tool "lintian" skimming over the prepared packages. Reports are shown on https://lintian.debian.org/sources/berkeley-abc which points to some typos that this PR duly addresses.