### PR TITLE
fix windows CI => project file integration broken on windows-latest

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,7 +4,7 @@ jobs:
 
   build-windows:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
 


### PR DESCRIPTION
use windows-2019 until updated project files are usable on 2022