### PR TITLE
Fix compile error on targets with unsigned char

### DIFF
--- a/src/misc/extra/extraUtilMisc.c
+++ b/src/misc/extra/extraUtilMisc.c
@@ -1290,7 +1290,7 @@ void Extra_TruthExpand( int nVars, int nWords, unsigned * puTruth, unsigned uPha
         { 0x00000000,0x00000000,0xFFFFFFFF,0xFFFFFFFF,0x00000000,0x00000000,0xFFFFFFFF,0xFFFFFFFF }, 
         { 0x00000000,0x00000000,0x00000000,0x00000000,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF } 
     };
-    static char Cases[256] = {
+    static signed char Cases[256] = {
          0, // 00000000
          0, // 00000001
          1, // 00000010


### PR DESCRIPTION
abc is failing to compile on ppc64le because char is unsigned by
default:

src/misc/extra/extraUtilMisc.c: In function ‘void abc::Extra_TruthExpand(int, int, unsigned int*, unsigned int, unsigned int*)’:
src/misc/extra/extraUtilMisc.c:1550:5: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]