### PR TITLE
Prevent types from stdint to be defined under abc namespace

### DIFF
--- a/src/misc/util/abc_global.h
+++ b/src/misc/util/abc_global.h
@@ -94,8 +94,6 @@
 ///                         PARAMETERS                               ///
 ////////////////////////////////////////////////////////////////////////
 
-ABC_NAMESPACE_HEADER_START
-
 ////////////////////////////////////////////////////////////////////////
 ///                         BASIC TYPES                              ///
 ////////////////////////////////////////////////////////////////////////
@@ -142,6 +140,8 @@ ABC_NAMESPACE_HEADER_START
 #endif
 
 #endif
+
+ABC_NAMESPACE_HEADER_START
 
 /**
  * Pointer difference type; replacement for ptrdiff_t.


### PR DESCRIPTION
Without this change, I get following error with latest gcc and clang

```
In file included from src/base/abci/abc.c:69:
/usr/include/unistd.h:1076:20: error: ‘intptr_t’ was not declared in this scope; did you mean ‘abc::intptr_t’?
 1076 | extern void *sbrk (intptr_t __delta) __THROW;
      |                    ^~~~~~~~
      |                    abc::intptr_t
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/12.1.0/include/stdint.h:9,
                 from ./src/misc/util/abc_global.h:108,
                 from ./src/misc/vec/vec.h:29,
                 from ./src/base/abc/abc.h:34,
                 from src/base/abci/abc.c:21:
/usr/include/stdint.h:87:33: note: ‘abc::intptr_t’ declared here
   87 | typedef long int                intptr_t;

```
