### PR TITLE
Fix variable name in makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 ifdef ABC_USE_NAMESPACE
   CFLAGS += -DABC_NAMESPACE=$(ABC_USE_NAMESPACE) -fpermissive -x c++
   CC := $(CXX)
-  $(info $(MSG_PREFIX)Compiling in namespace $(ABC_NAMESPACE))
+  $(info $(MSG_PREFIX)Compiling in namespace $(ABC_USE_NAMESPACE))
 endif
 
 # compile CUDD with ABC


### PR DESCRIPTION
The namespace in makefile is ABC_USE_NAMESPACE. ABC_USE_NAMESPACE is visible only in source files.
