### PR TITLE
Fix two instances of use after free

### DIFF
--- a/src/base/cmd/cmdLoad.c
+++ b/src/base/cmd/cmdLoad.c
@@ -58,8 +58,8 @@ int CmdCommandLoad( Abc_Frame_t * pAbc, int argc, char ** argv )
     // check if there is the binary
     if ( (pFile = fopen( Vec_StrArray(vCommand), "r" )) == NULL )
     {
-        Vec_StrFree( vCommand );
         Abc_Print( -1, "Cannot run the binary \"%s\".\n\n", Vec_StrArray(vCommand) );
+        Vec_StrFree( vCommand );
         return 1;
     }
     fclose( pFile );
@@ -74,9 +74,9 @@ int CmdCommandLoad( Abc_Frame_t * pAbc, int argc, char ** argv )
     // run the command line
     if ( Util_SignalSystem( Vec_StrArray(vCommand) ) )
     {
-        Vec_StrFree( vCommand );
         Abc_Print( -1, "The following command has returned non-zero exit status:\n" );
         Abc_Print( -1, "\"%s\"\n", Vec_StrArray(vCommand) );
+        Vec_StrFree( vCommand );
         return 1;
     }
     Vec_StrFree( vCommand );


### PR DESCRIPTION
Both were identified by GCC using `-Wuse-after-free`.
