### PR TITLE
Do not pass NULL to fprintf

### DIFF
--- a/src/base/exor/exorUtil.c
+++ b/src/base/exor/exorUtil.c
@@ -189,7 +189,7 @@ int WriteResultIntoFile( char * pFileName )
     pFile = fopen( pFileName, "w" );
     if ( pFile == NULL )
     {
-        fprintf( pFile, "\n\nCannot open the output file\n" );
+        fprintf( stderr, "\n\nCannot open the output file\n" );
         return 1;
     }
 


### PR DESCRIPTION
Fix a guaranteed segfault.  This was found with the GCC option `-Wnonnull`.
