### PR TITLE
Workaround for a crash when compiling on macOS in GitHub Actions.

### DIFF
--- a/.github/workflows/build-posix-cmake.yml
+++ b/.github/workflows/build-posix-cmake.yml
@@ -5,7 +5,7 @@ jobs:
   build-posix:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-11, ubuntu-latest]
         use_namespace: [false, true]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Reported the bug to Apple and return to the previous version of the maOS image (macos-11).