### PR TITLE
Do not perform check for cycles if design is not hierarchic

### DIFF
--- a/src/base/io/ioUtil.c
+++ b/src/base/io/ioUtil.c
@@ -157,7 +157,7 @@ Abc_Ntk_t * Io_ReadNetlist( char * pFileName, Io_FileType_t FileType, int fCheck
         fprintf( stdout, "Reading network from file has failed.\n" );
         return NULL;
     }
-    if ( fCheck && (Abc_NtkBlackboxNum(pNtk) || Abc_NtkWhiteboxNum(pNtk)) )
+    if ( pNtk->pDesign && fCheck && (Abc_NtkBlackboxNum(pNtk) || Abc_NtkWhiteboxNum(pNtk)) )
     {
         int i, fCycle = 0;
         Abc_Ntk_t * pModel;


### PR DESCRIPTION
Dereference of pNtk->pDesign leads to segmentation fault