### PR TITLE
Fix segv constr

### DIFF
--- a/src/map/scl/sclSize.c
+++ b/src/map/scl/sclSize.c
@@ -197,7 +197,7 @@ void Abc_SclTimeNtkPrint( SC_Man * p, int fShowAll, int fPrintPath )
         while ( pObj && Abc_ObjIsNode(pObj) )
         {
             i++;
-            nLength = Abc_MaxInt( nLength, strlen((Abc_SclObjCell(pObj) ? Abc_SclObjCell(pObj)->pName : "pi")) );
+            nLength = Abc_MaxInt( nLength, Abc_SclObjCell(pObj) ? strlen(Abc_SclObjCell(pObj)->pName) : 2 /* strlen("pi") */ );
             pObj = Abc_SclFindMostCriticalFanin( p, &fRise, pObj );
         }
 

--- a/src/map/scl/sclSize.c
+++ b/src/map/scl/sclSize.c
@@ -197,7 +197,7 @@ void Abc_SclTimeNtkPrint( SC_Man * p, int fShowAll, int fPrintPath )
         while ( pObj && Abc_ObjIsNode(pObj) )
         {
             i++;
-            nLength = Abc_MaxInt( nLength, strlen(Abc_SclObjCell(pObj)->pName) );
+            nLength = Abc_MaxInt( nLength, strlen((Abc_SclObjCell(pObj) ? Abc_SclObjCell(pObj)->pName : "pi")) );
             pObj = Abc_SclFindMostCriticalFanin( p, &fRise, pObj );
         }
 


### PR DESCRIPTION
When using constraints and when the logic gets optimized to a wire, the pObj may be a primary input. This causes a segfault. This fix treats the name as "pi" (similar to other places in the code).