### PR TITLE
fix errors when compiling within Yosys: "ISO C++17 does not allow 'register' storage class specifier"

### DIFF
--- a/src/bdd/cudd/cuddBddIte.c
+++ b/src/bdd/cudd/cuddBddIte.c
@@ -1203,8 +1203,8 @@ bddVarToCanonical(
   unsigned int * topgp,
   unsigned int * tophp)
 {
-    register DdNode             *F, *G, *H, *r, *f, *g, *h;
-    register unsigned int       topf, topg, toph;
+    DdNode             *F, *G, *H, *r, *f, *g, *h;
+    unsigned int       topf, topg, toph;
     DdNode                      *one = dd->one;
     int                         comple, change;
 
@@ -1305,7 +1305,7 @@ bddVarToCanonicalSimple(
   unsigned int * topgp,
   unsigned int * tophp)
 {
-    register DdNode             *r, *f, *g, *h;
+    DdNode             *r, *f, *g, *h;
     int                         comple, change;
 
     f = *fp;

--- a/src/bdd/cudd/cuddCache.c
+++ b/src/bdd/cudd/cuddCache.c
@@ -229,7 +229,7 @@ cuddCacheInsert(
 {
     int posn;
     unsigned hash;
-    register DdCache *entry;
+    DdCache *entry;
     ptruint uf, ug, uh;
     ptruint ufc, ugc, uhc;
 
@@ -283,7 +283,7 @@ cuddCacheInsert2(
 {
     int posn;
     unsigned hash;
-    register DdCache *entry;
+    DdCache *entry;
 
     hash = ddCHash2_(op,cuddF2L(f),cuddF2L(g));
 //    posn = ddCHash2(op,cuddF2L(f),cuddF2L(g),table->cacheShift);
@@ -328,7 +328,7 @@ cuddCacheInsert1(
 {
     int posn;
     unsigned hash;
-    register DdCache *entry;
+    DdCache *entry;
 
     hash = ddCHash2_(op,cuddF2L(f),cuddF2L(f));
 //    posn = ddCHash2(op,cuddF2L(f),cuddF2L(f),table->cacheShift);

--- a/src/bdd/cudd/cuddSat.c
+++ b/src/bdd/cudd/cuddSat.c
@@ -279,7 +279,7 @@ Cudd_LargestCube(
   DdNode * f,
   int * length)
 {
-    register    DdNode  *F;
+       DdNode  *F;
     st__table    *visited;
     DdNode      *sol;
     cuddPathPair *rootPair;
@@ -351,7 +351,7 @@ Cudd_ShortestLength(
   DdNode * f,
   int * weight)
 {
-    register    DdNode  *F;
+       DdNode  *F;
     st__table    *visited;
     cuddPathPair *my_pair;
     int         complement, cost;

--- a/src/bdd/cudd/cuddSplit.c
+++ b/src/bdd/cudd/cuddSplit.c
@@ -638,8 +638,8 @@ bddAnnotateMintermCount(
 {
 
     DdNode *N,*Nv,*Nnv;
-    register double min_v,min_nv;
-    register double min_N;
+    double min_v,min_nv;
+    double min_N;
     double *pmin;
     double *dummy;
 

--- a/src/misc/bzlib/compress.c
+++ b/src/misc/bzlib/compress.c
@@ -190,15 +190,15 @@ void generateMTFValues ( EState* s )
             zPend = 0;
          }
          {
-            register UChar  rtmp;
-            register UChar* ryy_j;
-            register UChar  rll_i;
+            UChar  rtmp;
+            UChar* ryy_j;
+            UChar  rll_i;
             rtmp  = yy[1];
             yy[1] = yy[0];
             ryy_j = &(yy[1]);
             rll_i = ll_i;
             while ( rll_i != rtmp ) {
-               register UChar rtmp2;
+               UChar rtmp2;
                ryy_j++;
                rtmp2  = rtmp;
                rtmp   = *ryy_j;
@@ -360,8 +360,8 @@ void sendMTFValues ( EState* s )
 
          if (nGroups == 6 && 50 == ge-gs+1) {
             /*--- fast track the common case ---*/
-            register UInt32 cost01, cost23, cost45;
-            register UInt16 icv;
+            UInt32 cost01, cost23, cost45;
+            UInt16 icv;
             cost01 = cost23 = cost45 = 0;
 
 #           define BZ_ITER(nn)                \

--- a/src/misc/extra/extraUtilUtil.c
+++ b/src/misc/extra/extraUtilUtil.c
@@ -97,8 +97,8 @@ void Extra_UtilGetoptReset()
 ***********************************************************************/
 int Extra_UtilGetopt( int argc, char *argv[], const char *optstring )
 {
-    register int c;
-    register const char *place;
+    int c;
+    const char *place;
 
     globalUtilOptarg = NULL;
 

--- a/src/misc/zlib/crc32.c
+++ b/src/misc/zlib/crc32.c
@@ -269,8 +269,8 @@ unsigned long ZEXPORT crc32(unsigned long crc, const unsigned char FAR *buf, uIn
 /* ========================================================================= */
 local unsigned long crc32_little(unsigned long crc, const unsigned char FAR *buf, unsigned len)
 {
-    register u4 c;
-    register const u4 FAR *buf4;
+    u4 c;
+    const u4 FAR *buf4;
 
     c = (u4)crc;
     c = ~c;
@@ -306,8 +306,8 @@ local unsigned long crc32_little(unsigned long crc, const unsigned char FAR *buf
 /* ========================================================================= */
 local unsigned long crc32_big(unsigned long crc, const unsigned char FAR *buf, unsigned len)
 {
-    register u4 c;
-    register const u4 FAR *buf4;
+    u4 c;
+    const u4 FAR *buf4;
 
     c = REV((u4)crc);
     c = ~c;

--- a/src/misc/zlib/deflate.c
+++ b/src/misc/zlib/deflate.c
@@ -1027,9 +1027,9 @@ local void lm_init (deflate_state *s)
 local uInt longest_match(deflate_state *s, IPos cur_match)
 {
     unsigned chain_length = s->max_chain_length;/* max hash chain length */
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
     int best_len = s->prev_length;              /* best match length so far */
     int nice_match = s->nice_match;             /* stop if match long enough */
     IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
@@ -1044,13 +1044,13 @@ local uInt longest_match(deflate_state *s, IPos cur_match)
     /* Compare two bytes at a time. Note: this is not always beneficial.
      * Try with and without -DUNALIGNED_OK to check.
      */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
-    register ush scan_start = *(ushf*)scan;
-    register ush scan_end   = *(ushf*)(scan+best_len-1);
+    Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
+    ush scan_start = *(ushf*)scan;
+    ush scan_end   = *(ushf*)(scan+best_len-1);
 #else
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
-    register Byte scan_end1  = scan[best_len-1];
-    register Byte scan_end   = scan[best_len];
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Byte scan_end1  = scan[best_len-1];
+    Byte scan_end   = scan[best_len];
 #endif
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
@@ -1173,10 +1173,10 @@ local uInt longest_match(deflate_state *s, IPos cur_match)
  */
 local uInt longest_match(deflate_state *s, IPos cur_match)
 {
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
      * It is easy to get rid of this optimization if necessary.
@@ -1261,8 +1261,8 @@ local void check_match(deflate_state *s, IPos start, IPos match, int length)
  */
 local void fill_window(deflate_state *s)
 {
-    register unsigned n, m;
-    register Posf *p;
+    unsigned n, m;
+    Posf *p;
     unsigned more;    /* Amount of free space at the end of the window. */
     uInt wsize = s->w_size;
 

--- a/src/misc/zlib/trees.c
+++ b/src/misc/zlib/trees.c
@@ -1144,7 +1144,7 @@ local int detect_data_type(deflate_state *s)
  */
 local unsigned bi_reverse(unsigned code, int len)
 {
-    register unsigned res = 0;
+    unsigned res = 0;
     do {
         res |= code & 1;
         code >>= 1, res <<= 1;


### PR DESCRIPTION
The error quoted above turned up when I went to update my Gentoo ebuild for the latest version of Yosys.  I knocked together a patch to fix it there, but it might not be a bad idea to fix it here instead.