### PR TITLE
Fix Segfault in scl

### DIFF
--- a/src/map/scl/sclSize.c
+++ b/src/map/scl/sclSize.c
@@ -200,7 +200,7 @@ void Abc_SclTimeNtkPrint( SC_Man * p, int fShowAll, int fPrintPath )
         while ( pObj && Abc_ObjIsNode(pObj) )
         {
             i++;
-            nLength = Abc_MaxInt( nLength, strlen(Abc_SclObjCell(pObj)->pName) );
+            nLength = Abc_MaxInt( nLength, Abc_SclObjCell(pObj) ? strlen(Abc_SclObjCell(pObj)->pName) : 2 /* strlen("pi") */ );
             pObj = Abc_SclFindMostCriticalFanin( p, &fRise, pObj );
         }
 


### PR DESCRIPTION
Fixes a regression that was introduced in #232 by myself.  
Reverts back to correct version introduced in #228.

This was likely introduced in a careless merge before creating PR #232.

Sorry for that.