### PR TITLE
Fix(&nf): Add delay transfer in &nf

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -9343,8 +9343,7 @@ usage:
     Abc_Print( -2, "\t           synthesizes the smallest circuit composed of two-input gates\n" );
     Abc_Print( -2, "\t           for the only NPN class of 5-input functions that requires 12 gates;\n" );
     Abc_Print( -2, "\t           all other functions can be realized with 11 two-input gates or less\n" );
-    Abc_Print( -2, "\t           (see Section 7.1.2 \"Boolean evaluation\" in the book by Donald Knuth\n" );
-    Abc_Print( -2, "\t           http://www.cs.utsa.edu/~wagner/knuth/fasc0c.pdf)\n" );
+    Abc_Print( -2, "\t           (see Section 7.1.2 \"Boolean evaluation\" in the book The Art of Computer Programming by Donald Knuth)\n" );
     return 1;
 }
 

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -3775,7 +3775,7 @@ usage:
     Abc_Print( -2, "usage: strash [-acrih]\n" );
     Abc_Print( -2, "\t        transforms combinational logic into an AIG\n" );
     Abc_Print( -2, "\t-a    : toggles between using all nodes and DFS nodes [default = %s]\n", fAllNodes? "all": "DFS" );
-    Abc_Print( -2, "\t-c    : toggles cleanup to remove the dagling AIG nodes [default = %s]\n", fCleanup? "all": "DFS" );
+    Abc_Print( -2, "\t-c    : toggles cleanup to remove the dangling AIG nodes [default = %s]\n", fCleanup? "all": "DFS" );
     Abc_Print( -2, "\t-r    : toggles using the record of AIG subgraphs [default = %s]\n", fRecord? "yes": "no" );
     Abc_Print( -2, "\t-i    : toggles complementing the POs of the AIG [default = %s]\n", fComplOuts? "yes": "no" );
     Abc_Print( -2, "\t-h    : print the command usage\n");

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -1547,7 +1547,7 @@ usage:
     Abc_Print( -2, "\t-f    : toggles printing the literal count in the factored forms [default = %s]\n", fFactor? "yes": "no" );
     Abc_Print( -2, "\t-b    : toggles saving the best logic network in \"best.blif\" [default = %s]\n", fSaveBest? "yes": "no" );
     Abc_Print( -2, "\t-d    : toggles dumping statistics about the network into file [default = %s]\n", fDumpResult? "yes": "no" );
-    Abc_Print( -2, "\t-l    : toggles printing delay of LUT mapping using LUT library [default = %s]\n", fSaveBest? "yes": "no" );
+    Abc_Print( -2, "\t-l    : toggles printing delay of LUT mapping using LUT library [default = %s]\n", fUseLutLib? "yes": "no" );
     Abc_Print( -2, "\t-t    : toggles printing runtime statistics [default = %s]\n", fPrintTime? "yes": "no" );
     Abc_Print( -2, "\t-m    : toggles printing MUX statistics [default = %s]\n", fPrintMuxes? "yes": "no" );
     Abc_Print( -2, "\t-p    : toggles printing power dissipation due to switching [default = %s]\n", fPower? "yes": "no" );

--- a/src/base/abci/abcLutmin.c
+++ b/src/base/abci/abcLutmin.c
@@ -430,10 +430,10 @@ Abc_Obj_t * Abc_NtkBddCurtis( Abc_Ntk_t * pNtkNew, Abc_Obj_t * pNode, Vec_Ptr_t 
     int b, c, u, i;
     assert( nBits + 2 <= nLutSize );
     assert( nLutSize < Abc_ObjFaninNum(pNode) );
-    // start BDDs for the decompoosed blocks
+    // start BDDs for the decomposed blocks
     for ( b = 0; b < nBits; b++ )
         bBits[b] = Cudd_ReadLogicZero(ddNew), Cudd_Ref( bBits[b] );
-    // add each bound set minterm to one of the blccks
+    // add each bound set minterm to one of the blocks
     Vec_PtrForEachEntry( DdNode *, vCofs, bCof, c )
     {
         Vec_PtrForEachEntry( DdNode *, vUniq, bUniq, u )

--- a/src/base/io/ioReadAiger.c
+++ b/src/base/io/ioReadAiger.c
@@ -440,7 +440,7 @@ Abc_Ntk_t * Io_ReadAiger( char * pFileName, int fCheck )
             }
             if ( *pCur != '\n' )
             {
-                fprintf( stdout, "The initial value of latch number %d is not recongnized.\n", i );
+                fprintf( stdout, "The initial value of latch number %d is not recognized.\n", i );
                 return NULL;
             }
             pCur++;

--- a/src/base/io/ioReadAiger.c
+++ b/src/base/io/ioReadAiger.c
@@ -433,7 +433,7 @@ Abc_Ntk_t * Io_ReadAiger( char * pFileName, int fCheck )
                 else 
                 {
                     assert( Init == Abc_Var2Lit(1+Abc_NtkPiNum(pNtkNew)+i, 0) ); 
-                    // unitialized value of the latch is the latch literal according to http://fmv.jku.at/hwmcc11/beyond1.pdf
+                    // uninitialized value of the latch is the latch literal according to http://fmv.jku.at/hwmcc11/beyond1.pdf
                     Abc_LatchSetInitDc( Abc_NtkBox(pNtkNew, i) );
                 }
                 while ( *pCur != ' ' && *pCur != '\n' ) pCur++;

--- a/src/base/io/ioWriteAiger.c
+++ b/src/base/io/ioWriteAiger.c
@@ -680,7 +680,7 @@ void Io_WriteAiger( Abc_Ntk_t * pNtk, char * pFileName, int fWriteSymbols, int f
     b.f = fopen( pFileName, "wb" ); 
     if ( b.f == NULL )
     {
-        fprintf( stdout, "Ioa_WriteBlif(): Cannot open the output file \"%s\".\n", pFileName );
+        fprintf( stdout, "Io_WriteAiger(): Cannot open the output file \"%s\".\n", pFileName );
         ABC_FREE(b.buf);
         return;
     }
@@ -688,7 +688,7 @@ void Io_WriteAiger( Abc_Ntk_t * pNtk, char * pFileName, int fWriteSymbols, int f
         b.b = BZ2_bzWriteOpen( &bzError, b.f, 9, 0, 0 );
         if ( bzError != BZ_OK ) {
             BZ2_bzWriteClose( &bzError, b.b, 0, NULL, NULL );
-            fprintf( stdout, "Ioa_WriteBlif(): Cannot start compressed stream.\n" );
+            fprintf( stdout, "Io_WriteAiger(): Cannot start compressed stream.\n" );
             fclose( b.f );
             ABC_FREE(b.buf);
             return;

--- a/src/map/mapper/mapper.h
+++ b/src/map/mapper/mapper.h
@@ -30,6 +30,8 @@
 
 
 
+#include "base/abc/abc.h"
+#include "map/mio/mio.h"
 ABC_NAMESPACE_HEADER_START
 
 

--- a/src/misc/bbl/bblif.h
+++ b/src/misc/bbl/bblif.h
@@ -237,7 +237,7 @@ extern void        Bbl_ManDumpBinaryBlif( Bbl_Man_t * p, char * pFileName );
 // (3) reading the data manager from file
 extern Bbl_Man_t * Bbl_ManReadBinaryBlif( char * pFileName );
 
-// (4) returning the mapped network after reading the data manaager from file
+// (4) returning the mapped network after reading the data manager from file
 extern char *      Bbl_ManName( Bbl_Man_t * p );
 extern int         Bbl_ObjIsInput( Bbl_Obj_t * p );
 extern int         Bbl_ObjIsOutput( Bbl_Obj_t * p );


### PR DESCRIPTION
#262 


After adding delay info, now the delay is not calculated by the initial `1.00` value:

```
ABC command line: "source -x /Users/jingrenwang/Github/ABC/abcOri/abc/testrec.script".

abc - > read_lib /Users/jingrenwang/Github/ABC/abcOri/abc/NangateOpenCellLibrary_typical.lib
Library "NangateOpenCellLibrary" from "/Users/jingrenwang/Github/ABC/abcOri/abc/NangateOpenCellLibrary_typical.lib" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.06 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").
abc - > read_aiger /Users/jingrenwang/Github/ABC/abcOri/abc/i10.aig
abc - > &get
abc - > &nf -v
Derived GENLIB library "NangateOpenCellLibrary" with 30 gates using slew 17.19 ps and gain 250.00.
   0 : _const0_               In = 0   N =   1   A =     0.000000   D =     0.000000
   1 : _const1_               In = 0   N =   1   A =     0.000000   D =     0.000000
   2 : BUF_X1                 In = 1   N =   9   A =     0.800000   D =    28.459999
   3 : INV_X1                 In = 1   N =   6   A =     0.530000   D =    15.230000
   4 : NAND2_X1               In = 2   N =   3   A =     0.800000   D =    21.405001
   5 : NOR2_X1                In = 2   N =   3   A =     0.800000   D =    26.830000
   6 : AND2_X1                In = 2   N =   3   A =     1.060000   D =    32.365002
   7 : OR2_X1                 In = 2   N =   3   A =     1.060000   D =    36.945000
   8 : XNOR2_X1               In = 2   N =   2   A =     1.600000   D =    54.185001
   9 : XOR2_X1                In = 2   N =   2   A =     1.600000   D =    65.220001
  10 : AOI21_X1               In = 3   N =   3   A =     1.060000   D =    32.952999
  11 : NAND3_X1               In = 3   N =   3   A =     1.060000   D =    27.886000
  12 : NOR3_X1                In = 3   N =   3   A =     1.060000   D =    39.520000
  13 : OAI21_X1               In = 3   N =   3   A =     1.060000   D =    30.780001
  14 : AND3_X1                In = 3   N =   3   A =     1.330000   D =    38.542999
  15 : OR3_X1                 In = 3   N =   3   A =     1.330000   D =    49.750000
  16 : MUX2_X1                In = 3   N =   2   A =     1.860000   D =    54.063000
  17 : AOI211_X1              In = 4   N =   3   A =     1.330000   D =    55.117001
  18 : AOI22_X1               In = 4   N =   3   A =     1.330000   D =    38.619999
  19 : NAND4_X1               In = 4   N =   3   A =     1.330000   D =    34.181999
  20 : NOR4_X1                In = 4   N =   3   A =     1.330000   D =    54.827000
  21 : OAI211_X1              In = 4   N =   3   A =     1.330000   D =    35.891998
  22 : OAI22_X1               In = 4   N =   3   A =     1.330000   D =    37.919998
  23 : AND4_X1                In = 4   N =   3   A =     1.600000   D =    45.137001
  24 : OR4_X1                 In = 4   N =   3   A =     1.600000   D =    64.067001
  25 : AOI221_X1              In = 5   N =   3   A =     1.600000   D =    62.798000
  26 : OAI221_X1              In = 5   N =   3   A =     1.600000   D =    52.396000
  27 : OAI33_X1               In = 6   N =   1   A =     1.860000   D =    56.060001
  28 : AOI222_X1              In = 6   N =   3   A =     2.130000   D =    70.102997
  29 : OAI222_X1              In = 6   N =   3   A =     2.130000   D =    59.389999
LutSize = 6  CutNum = 16  Iter = 4  Coarse = 0   Cells = 30  Funcs = 2291  Matches = 28512  And = 2675  
Computing cuts...
CutPair = 319021  Merge = 123135 (46.0)  Eval = 84235 (31.5)  Cut = 31872 (11.9)  Use = 14015 (5.2)  Mat = 107231 (40.1)  
Gia = 0.04 MB  Man = 0.29 MB  Cut = 0.75 MB   TT = 0.16 MB  Total = 1.23 MB   Time =     0.02 sec
Delay :  Delay =  727.80  Area =     1985.67  Gate =  1773  Inv =   100  Edge =   4834  Time =     0.02 sec
Area  :  Delay =  727.80  Area =     1778.64  Gate =  1618  Inv =   113  Edge =   4341  Time =     0.02 sec
Area  :  Delay =  727.80  Area =     1694.33  Gate =  1543  Inv =   134  Edge =   4121  Time =     0.02 sec
Area  :  Delay =  727.80  Area =     1663.23  Gate =  1508  Inv =   142  Edge =   4019  Time =     0.02 sec
Ela   :  Delay =  727.80  Area =     1575.42  Gate =  1428  Inv =   127  Edge =   3840  Time =     0.02 sec
Ela   :  Delay =  727.80  Area =     1563.26  Gate =  1426  Inv =   124  Edge =   3849  Time =     0.03 sec
abc - > &put
abc - > ps
[1;37m/Users/jingrenwang/Github/ABC/abcOri/abc/i10:[0m i/o =  257/  224  lat =    0  nd =  1423  edge =   3832  area =1556.87  delay =758.78  lev = 25
abc - > print_delay
Critical path from PI "pi028" to PO "po011":
Level   0 : Primary input "pi028".   Arrival time =   0.0. 
Level   1 :       n499/A    (INV_X1)      Arrival =  15.2.   I/O times: (0.0 -> 15.2)
Level   2 :       n565/A1   (NOR3_X1)     Arrival =  49.0.   I/O times: (15.2, 0.0, 0.0 -> 49.0)
Level   3 :       n567/A4   (NAND4_X1)    Arrival =  86.2.   I/O times: (0.0, 0.0, 49.0, 49.0 -> 86.2)
Level   4 :       n569/B2   (AOI21_X1)    Arrival = 119.6.   I/O times: (0.0, 84.9, 86.2 -> 119.6)
Level   5 :       n576/B1   (AOI21_X1)    Arrival = 149.6.   I/O times: (93.9, 119.6, 28.9 -> 149.6)
Level   6 :       n577/A1   (NOR3_X1)     Arrival = 183.4.   I/O times: (149.6, 15.2, 0.0 -> 183.4)
Level   7 :       n578/A1   (NAND3_X1)    Arrival = 208.8.   I/O times: (183.4, 84.1, 15.2 -> 208.8)
Level   8 :       n579/A    (INV_X1)      Arrival = 224.1.   I/O times: (208.8 -> 224.1)
Level   9 :       n651/A1   (NAND4_X1)    Arrival = 254.0.   I/O times: (224.1, 132.6, 128.0, 15.2 -> 254.0)
Level  10 :       n823/A1   (NAND3_X1)    Arrival = 279.4.   I/O times: (254.0, 195.6, 195.6 -> 279.4)
Level  11 :       n824/A2   (NOR3_X1)     Arrival = 320.3.   I/O times: (241.9, 279.4, 169.5 -> 320.3)
Level  12 :       n825/A3   (NAND3_X1)    Arrival = 350.1.   I/O times: (318.1, 254.0, 320.3 -> 350.1)
Level  13 :       n827/A1   (AND2_X1)     Arrival = 381.7.   I/O times: (350.1, 342.7 -> 381.7)
Level  14 :       n828/A    (INV_X1)      Arrival = 396.9.   I/O times: (381.7 -> 396.9)
Level  15 :       n855/A    (XNOR2_X1)    Arrival = 448.9.   I/O times: (396.9, 255.9 -> 448.9)
Level  16 :       n857/A2   (NAND4_X1)    Arrival = 482.7.   I/O times: (435.6, 448.9, 432.2, 152.9 -> 482.7)
Level  17 :       n859/A3   (OR3_X1)      Arrival = 536.4.   I/O times: (22.7, 443.1, 482.7 -> 536.4)
Level  18 :      n1095/A1   (NAND3_X1)    Arrival = 561.8.   I/O times: (536.4, 527.8, 258.3 -> 561.8)
Level  20 :      n1096/B2   (OAI21_X1)    Arrival = 596.9.   I/O times: (44.1, 545.3, 561.8 -> 596.9)
Level  21 :      n1097/A2   (AND2_X1)     Arrival = 630.0.   I/O times: (569.7, 596.9 -> 630.0)
Level  22 :      n1098/B2   (AOI21_X1)    Arrival = 663.3.   I/O times: (0.0, 630.3, 630.0 -> 663.3)
Level  23 :      n1100/A1   (NAND4_X1)    Arrival = 693.3.   I/O times: (663.3, 365.4, 365.4, 365.4 -> 693.3)
Level  24 :      n1192/C1   (OAI211_X1)   Arrival = 728.5.   I/O times: (594.8, 107.0, 693.3, 69.1 -> 728.5)
Level  25 :      n1202/B1   (OAI21_X1)    Arrival = 758.8.   I/O times: (344.3, 728.5, 128.1 -> 758.8)
Level  26 : Primary output "po011".   Required time = -1000000000.0.  Path slack = -1000000768.0.
```