### PR TITLE
Fix(&dch): Transfer timing info when turn on minilevel

### DIFF
--- a/src/aig/gia/giaEquiv.c
+++ b/src/aig/gia/giaEquiv.c
@@ -806,6 +806,7 @@ Gia_Man_t * Gia_ManEquivReduce2( Gia_Man_t * p )
     Gia_ManHashStop( pNew );
     Gia_ManSetRegNum( pNew, Gia_ManRegNum(p) );
     Vec_IntFree( vMap );
+	Gia_ManTransferTiming( pNew, p );
     return pNew;
 }
 


### PR DESCRIPTION
The input Arrival time and output Required time are missing when turn on minilevel in &dch.