### PR TITLE
Micro-optimizations to speed up the Liberty parser by ~1.67x.

### DIFF
--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -281,26 +281,38 @@ static inline char * Scl_LibertyFindMatch( char * pPos, char * pEnd )
     assert( *pPos == '(' || *pPos == '{' );
     if ( *pPos == '(' )
     {
-        for ( ; pPos < pEnd; pPos++ )
-        {
-            if ( *pPos == '(' )
+      ++Counter;
+      ++pPos;
+      for ( ; pPos < pEnd; pPos++ )
+      {
+            // Invariant: Counter > 0.
+            if ( *pPos == '(' ) {
                 Counter++;
-            if ( *pPos == ')' )
+                continue;
+            }
+            else if ( *pPos == ')' ) {
                 Counter--;
-            if ( Counter == 0 )
-                break;
+                if ( Counter == 0 )
+                  break;
+            }
         }
     }
     else
     {
+        ++Counter;
+        ++pPos;
         for ( ; pPos < pEnd; pPos++ )
         {
-            if ( *pPos == '{' )
+            // Invariant: Counter > 0.
+            if ( *pPos == '{' ) {
                 Counter++;
-            if ( *pPos == '}' )
+                continue;
+            }
+            else if ( *pPos == '}' ) {
                 Counter--;
-            if ( Counter == 0 )
-                break;
+                if ( Counter == 0 )
+                  break;
+            }
         }
     }
     assert( *pPos == ')' || *pPos == '}' );
@@ -317,10 +329,14 @@ static inline Scl_Pair_t Scl_LibertyUpdateHead( Scl_Tree_t * p, Scl_Pair_t Head 
     char * pChar;
     for ( pChar = pBeg; pChar < pEnd; pChar++ )
     {
-        if ( *pChar == '\n' )
+        if ( *pChar == '\n' ) {
             p->nLines++;
-        if ( Scl_LibertyCharIsSpace(*pChar) )
+            // Note: Scl_LibertyCharIsSpace returns true for '\n', so we can
+            // continue here and save the call to Scl_LibertyCharIsSpace.
             continue;
+        } else if ( Scl_LibertyCharIsSpace(*pChar) ) {
+            continue;
+        }
         pLastNonSpace = pChar;
         if ( pFirstNonSpace == NULL )
             pFirstNonSpace = pChar;


### PR DESCRIPTION
This change makes a few micro-optimizations to the Liberty parser, based on profiling it on an x86-based Linux system using the Clang compiler. Our application invokes the EDA tools on a relatively small circuit in a loop, so startup and parsing costs can be substantial for us.

The changes in the pull request reduced the time spent in  Scl_LibertyBuildItem and its children by 1.67x. 

Top-down view before:
![image](https://github.com/berkeley-abc/abc/assets/16907534/686fb92e-35e9-46ff-86b5-b7bb8d47dddf)

Top-down view after:
![image](https://github.com/berkeley-abc/abc/assets/16907534/b41bb20f-add7-4203-a09e-b2fc613b1714)

