### PR TITLE
Remove prefixing of stdcell names when using multiple liberty files.

### DIFF
--- a/src/map/scl/sclLibScl.c
+++ b/src/map/scl/sclLibScl.c
@@ -483,7 +483,7 @@ static void Abc_SclWriteSurface( Vec_Str_t * vOut, SC_Surface * p )
     for ( i = 0; i < 6; i++ ) 
         Vec_StrPutF( vOut, p->approx[2][i] );
 }
-static void Abc_SclWriteLibraryCellsOnly( Vec_Str_t * vOut, SC_Lib * p)
+static void Abc_SclWriteLibraryCellsOnly( Vec_Str_t * vOut, SC_Lib * p )
 {
     SC_Cell * pCell;
     SC_Pin * pPin;


### PR DESCRIPTION
Typically, multiple liberty files are used to specify additional cells for multi-height or multi-Vt technologies. These cells have different names from each other and are unique across a tech library, so prefixing their name is not required. This allows downstream tools that ingest tech-mapped netlists from abc to recognize the stdcells.