### PR TITLE
Fix prototype mismatch for `Gia_ManSimRsb`

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -35012,7 +35012,7 @@ usage:
 ***********************************************************************/
 int Abc_CommandAbc9SimRsb( Abc_Frame_t * pAbc, int argc, char ** argv )
 {
-    extern void Gia_ManSimRsb( Gia_Man_t * p, int nCands, int fVerbose );
+    extern int Gia_ManSimRsb( Gia_Man_t * p, int nCands, int fVerbose );
     int c, nCands = 32, fVerbose = 0;
     Extra_UtilGetoptReset();
     while ( ( c = Extra_UtilGetopt( argc, argv, "Nvh" ) ) != EOF )


### PR DESCRIPTION
Detected by a WASM build (done with some other patches carried in the Yosys fork)

```
[100%] Building yosys.wasm
wasm-ld: warning: function signature mismatch: _ZN3abc13Gia_ManSimRsbEPNS_10Gia_Man_t_Eii
>>> defined as (i32, i32, i32) -> void in yosys-libabc.a(abc.o)
>>> defined as (i32, i32, i32) -> i32 in yosys-libabc.a(giaSimBase.o)
```