### PR TITLE
Modify include guards in cmd.c so that Windows compilers don't compil…

### DIFF
--- a/src/base/cmd/cmd.c
+++ b/src/base/cmd/cmd.c
@@ -51,7 +51,7 @@ static int CmdCommandUnsetVariable ( Abc_Frame_t * pAbc, int argc, char ** argv 
 static int CmdCommandUndo          ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int CmdCommandRecall        ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int CmdCommandEmpty         ( Abc_Frame_t * pAbc, int argc, char ** argv );
-#if defined(WIN32) && !defined(__cplusplus)
+#if defined(WIN32)
 static int CmdCommandScanDir       ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int CmdCommandRenameFiles   ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int CmdCommandLs            ( Abc_Frame_t * pAbc, int argc, char ** argv );
@@ -105,7 +105,7 @@ void Cmd_Init( Abc_Frame_t * pAbc )
     Cmd_CommandAdd( pAbc, "Basic", "undo",          CmdCommandUndo,            0 );
     Cmd_CommandAdd( pAbc, "Basic", "recall",        CmdCommandRecall,          0 );
     Cmd_CommandAdd( pAbc, "Basic", "empty",         CmdCommandEmpty,           0 );
-#if defined(WIN32) && !defined(__cplusplus)
+#if defined(WIN32)
     Cmd_CommandAdd( pAbc, "Basic", "scandir",       CmdCommandScanDir,         0 );
     Cmd_CommandAdd( pAbc, "Basic", "renamefiles",   CmdCommandRenameFiles,     0 );
     Cmd_CommandAdd( pAbc, "Basic", "ls",            CmdCommandLs,              0 );
@@ -1209,7 +1209,7 @@ usage:
 #endif
 
 
-#if defined(WIN32) && !defined(__cplusplus)
+#if defined(WIN32)
 #include <direct.h>
 #include <io.h>
 
@@ -1395,10 +1395,10 @@ int CmfFindNumber( char * pName )
 ***********************************************************************/
 void CnfDupFileUnzip( char * pOldName )
 {
-    extern char * Io_MvLoadFileBz2( char * pFileName, int * pnFileSize );
+    extern char * Io_MvLoadFileBz2( char * pFileName, long * pnFileSize );
     char pNewName[1000];
     FILE * pFile;
-    int nFileSize;
+    long nFileSize;
     char * pBuffer = Io_MvLoadFileBz2( pOldName, &nFileSize );
     assert( strlen(pOldName) < 1000 );
     sprintf( pNewName, "%s.v", pOldName );


### PR DESCRIPTION
…e Unix-only code.

In 7fd4b01fb3e, functions like `alphasort` and `scandir` that are not available on Windows were added to [a codepath](https://github.com/berkeley-abc/abc/blob/master/src/base/cmd/cmd.c#L1904) that Windows compilers can see (when compiling, for instance, using a C++ compiler). This leads to errors such as: `src/base/cmd/cmd.c:1904:21: error: 'scandir' was not declared in this scope; did you mean 'srand'?`. 

I've updated the include guards to work around those codepaths, and confirmed a successful compile and test run (`synth_ice40` on a non-empty design) with `yosys`. These changes took a while to propagate to `yosys`, which is why it took me a while to notice.