### PR TITLE
Change Scl_Pair_t_ membes to long to enable larger liberty file loading.

### DIFF
--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -49,8 +49,8 @@ typedef enum {
 typedef struct Scl_Pair_t_ Scl_Pair_t;
 struct Scl_Pair_t_
 {
-    int             Beg;          // item beginning
-    int             End;          // item end
+    long            Beg;          // item beginning
+    long            End;          // item end
 };
 
 typedef struct Scl_Item_t_ Scl_Item_t;


### PR DESCRIPTION
Large liberty files can fail to load with the existing 32-bit members in `Scl_Pair_t_` struct. This change will enable abc to parse these files.