### PR TITLE
Make `lbool` explicitly signed

### DIFF
--- a/src/sat/bsat/satVec.h
+++ b/src/sat/bsat/satVec.h
@@ -130,7 +130,9 @@ static inline void   vecp_remove(vecp* v, void* e)
 typedef int    lit;
 typedef int    cla;
 
-typedef char               lbool;
+// Explicitly make it signed so promotion-to-int behavior doesn't vary
+// across platforms that define signedness of char differently.
+typedef signed char lbool;
 
 static const int   var_Undef = -1;
 static const lit   lit_Undef = -2;


### PR DESCRIPTION
This avoids issues due to some platforms making `char` signed and others unsigned. For example, currently the result of promoting `(lbool)-1` to `int` can differ on different platforms. See
https://github.com/lsils/mockturtle/blob/50ffa108484ba65b44eee4a713832b7ee821d6d8/lib/bill/bill/sat/interface/abc_bsat2.hpp#L156 for an example of that.