### PR TITLE
Instead of throwing C++ exceptions, just print an error message and a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ ifdef ABC_USE_LIBSTDCXX
 endif
 
 $(info $(MSG_PREFIX)Using CFLAGS=$(CFLAGS))
-CXXFLAGS += $(CFLAGS) -std=c++17
+CXXFLAGS += $(CFLAGS) -std=c++17 -fno-exceptions
 
 SRC  :=
 GARBAGE := core core.* *.stackdump ./tags $(PROG) arch_flags

--- a/src/aig/gia/giaNewBdd.h
+++ b/src/aig/gia/giaNewBdd.h
@@ -21,6 +21,7 @@
 #ifndef ABC__aig__gia__giaNewBdd_h
 #define ABC__aig__gia__giaNewBdd_h
 
+#include <cstdlib>
 #include <limits>
 #include <vector>
 #include <iostream>
@@ -47,6 +48,11 @@ namespace NewBdd {
   static inline uniq UniqHash(lit Arg0, lit Arg1) { return Arg0 + 4256249 * Arg1;            }
   static inline cac  CacHash(lit Arg0, lit Arg1)  { return Arg0 + 4256249 * Arg1;            }
 
+  static inline void fatal_error(const char* message) {
+    std::cerr << message << std::endl;
+    std::abort();
+  }
+
   class Cache {
   private:
     cac    nSize;
@@ -62,10 +68,10 @@ namespace NewBdd {
   public:
     Cache(int nCacheSizeLog, int nCacheMaxLog, int nVerbose): nVerbose(nVerbose) {
       if(nCacheMaxLog < nCacheSizeLog)
-        throw std::invalid_argument("nCacheMax must not be smaller than nCacheSize");
+        fatal_error("nCacheMax must not be smaller than nCacheSize");
       nMax = (cac)1 << nCacheMaxLog;
       if(!(nMax << 1))
-        throw std::length_error("Memout (nCacheMax) in init");
+        fatal_error("Memout (nCacheMax) in init");
       nSize = (cac)1 << nCacheSizeLog;
       if(nVerbose)
         std::cout << "Allocating " << nSize << " cache entries" << std::endl;
@@ -242,7 +248,7 @@ namespace NewBdd {
     inline ref  Ref(lit x)                const { return vRefs[Lit2Bvar(x)];                                }
     inline double OneCount(lit x)         const {
       if(vOneCounts.empty())
-        throw std::logic_error("fCountOnes was not set");
+        fatal_error("fCountOnes was not set");
       if(LitIsCompl(x))
         return std::pow(2.0, nVars) - vOneCounts[Lit2Bvar(x)];
       return vOneCounts[Lit2Bvar(x)];
@@ -454,7 +460,7 @@ namespace NewBdd {
           if(nGbc > 1)
             fRemoved = Gbc();
           if(!Resize() && !fRemoved && (nGbc != 1 || !Gbc()))
-            throw std::length_error("Memout (node)");
+            fatal_error("Memout (node)");
         } else
           break;
       }
@@ -659,29 +665,29 @@ namespace NewBdd {
       nVerbose = p.nVerbose;
       // parameter sanity check
       if(p.nObjsMaxLog < p.nObjsAllocLog)
-        throw std::invalid_argument("nObjsMax must not be smaller than nObjsAlloc");
+        fatal_error("nObjsMax must not be smaller than nObjsAlloc");
       if(nVars_ >= (int)VarMax())
-        throw std::length_error("Memout (nVars) in init");
+        fatal_error("Memout (nVars) in init");
       nVars = nVars_;
       lit nObjsMaxLit = (lit)1 << p.nObjsMaxLog;
       if(!nObjsMaxLit)
-        throw std::length_error("Memout (nObjsMax) in init");
+        fatal_error("Memout (nObjsMax) in init");
       if(nObjsMaxLit > (lit)BvarMax())
         nObjsMax = BvarMax();
       else
         nObjsMax = (bvar)nObjsMaxLit;
       lit nObjsAllocLit = (lit)1 << p.nObjsAllocLog;
       if(!nObjsAllocLit)
-        throw std::length_error("Memout (nObjsAlloc) in init");
+        fatal_error("Memout (nObjsAlloc) in init");
       if(nObjsAllocLit > (lit)BvarMax())
         nObjsAlloc = BvarMax();
       else
         nObjsAlloc = (bvar)nObjsAllocLit;
       if(nObjsAlloc <= (bvar)nVars)
-        throw std::invalid_argument("nObjsAlloc must be larger than nVars");
+        fatal_error("nObjsAlloc must be larger than nVars");
       uniq nUniqueSize = (uniq)1 << p.nUniqueSizeLog;
       if(!nUniqueSize)
-        throw std::length_error("Memout (nUniqueSize) in init");
+        fatal_error("Memout (nUniqueSize) in init");
       // allocation
       if(nVerbose)
         std::cout << "Allocating " << nObjsAlloc << " nodes and " << nVars << " x " << nUniqueSize << " unique table entries" << std::endl;
@@ -703,7 +709,7 @@ namespace NewBdd {
       }
       if(p.fCountOnes) {
         if(nVars > 1023)
-          throw std::length_error("nVars must be less than 1024 to count ones");
+          fatal_error("nVars must be less than 1024 to count ones");
         vOneCounts.resize(nObjsAlloc);
       }
       // set up cache

--- a/src/aig/gia/giaNewTt.h
+++ b/src/aig/gia/giaNewTt.h
@@ -21,6 +21,7 @@
 #ifndef ABC__aig__gia__giaNewTt_h
 #define ABC__aig__gia__giaNewTt_h
 
+#include <cstdlib>
 #include <limits>
 #include <iomanip>
 #include <iostream>
@@ -40,6 +41,11 @@ namespace NewTt {
   static inline lit  LitMax()  { return std::numeric_limits<lit>::max();  }
   static inline ref  RefMax()  { return std::numeric_limits<ref>::max();  }
   static inline size SizeMax() { return std::numeric_limits<size>::max(); }
+
+  static void fatal_error(const char* message) {
+    std::cerr << message << std::endl;
+    std::abort();
+  }
 
   struct Param {
     int  nObjsAllocLog;
@@ -182,35 +188,35 @@ namespace NewTt {
   public:
     Man(int nVars, Param p): nVars(nVars) {
       if(p.nObjsMaxLog < p.nObjsAllocLog)
-        throw std::invalid_argument("nObjsMax must not be smaller than nObjsAlloc");
+        fatal_error("nObjsMax must not be smaller than nObjsAlloc");
       if(nVars >= lww())
         nSize = 1ull << (nVars - lww());
       else
         nSize = 1;
       if(!nSize)
-        throw std::length_error("Memout (nVars) in init");
+        fatal_error("Memout (nVars) in init");
       if(!(nSize << p.nObjsMaxLog))
-        throw std::length_error("Memout (nObjsMax) in init");
+        fatal_error("Memout (nObjsMax) in init");
       lit nObjsMaxLit = (lit)1 << p.nObjsMaxLog;
       if(!nObjsMaxLit)
-        throw std::length_error("Memout (nObjsMax) in init");
+        fatal_error("Memout (nObjsMax) in init");
       if(nObjsMaxLit > (lit)BvarMax())
         nObjsMax = BvarMax();
       else
         nObjsMax = (bvar)nObjsMaxLit;
       lit nObjsAllocLit = (lit)1 << p.nObjsAllocLog;
       if(!nObjsAllocLit)
-        throw std::length_error("Memout (nObjsAlloc) in init");
+        fatal_error("Memout (nObjsAlloc) in init");
       if(nObjsAllocLit > (lit)BvarMax())
         nObjsAlloc = BvarMax();
       else
         nObjsAlloc = (bvar)nObjsAllocLit;
       if(nObjsAlloc <= (bvar)nVars)
-        throw std::invalid_argument("nObjsAlloc must be larger than nVars");
+        fatal_error("nObjsAlloc must be larger than nVars");
       nTotalSize = nSize << p.nObjsAllocLog;
       vVals.resize(nTotalSize);
       if(p.fCountOnes && nVars > 63)
-        throw std::length_error("nVars must be less than 64 to count ones");
+        fatal_error("nVars must be less than 64 to count ones");
       nObjs = 1;
       for(int i = 0; i < 6 && i < nVars; i++) {
         for(size j = 0; j < nSize; j++)
@@ -239,7 +245,7 @@ namespace NewTt {
         if(nGbc > 1)
           fRemoved = Gbc();
         if(!Resize() && !fRemoved && (nGbc != 1 || !Gbc()))
-          throw std::length_error("Memout (node)");
+          fatal_error("Memout (node)");
       }
       bvar zvar;
       if(nObjs < nObjsAlloc)

--- a/src/sat/glucose/Alloc.h
+++ b/src/sat/glucose/Alloc.h
@@ -100,7 +100,7 @@ void RegionAllocator<T>::capacity(uint32_t min_cap)
         cap += delta;
 
         if (cap <= prev_cap)
-            throw OutOfMemoryException();
+            fatal_out_of_memory();
     }
     //printf(" .. (%p) cap = %u\n", this, cap);
 
@@ -122,7 +122,7 @@ RegionAllocator<T>::alloc(int size)
     
     // Handle overflow:
     if (sz < prev_sz)
-        throw OutOfMemoryException();
+        fatal_out_of_memory();
 
     return prev_sz;
 }

--- a/src/sat/glucose/Vec.h
+++ b/src/sat/glucose/Vec.h
@@ -100,7 +100,7 @@ void vec<T>::capacity(int min_cap) {
     if (cap >= min_cap) return;
     int add = imax((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
     if (add > INT_MAX - cap || (((data = (T*)::realloc((void*)data, (cap += add) * sizeof(T))) == NULL) && errno == ENOMEM))
-        throw OutOfMemoryException();
+        fatal_out_of_memory();
  }
 
 

--- a/src/sat/glucose/XAlloc.h
+++ b/src/sat/glucose/XAlloc.h
@@ -34,12 +34,18 @@ namespace Gluco {
 //=================================================================================================
 // Simple layer on top of malloc/realloc to catch out-of-memory situtaions and provide some typing:
 
-class OutOfMemoryException{};
+static inline void fatal_out_of_memory()
+{
+    fputs("Out of memory\n", stderr);
+    abort();
+}
+
 static inline void* xrealloc(void *ptr, size_t size)
 {
     void* mem = realloc(ptr, size);
     if (mem == NULL && errno == ENOMEM){
-        throw OutOfMemoryException();
+        fatal_out_of_memory();
+        return NULL;
     }else {
         return mem;
     }

--- a/src/sat/glucose2/Alloc.h
+++ b/src/sat/glucose2/Alloc.h
@@ -100,7 +100,7 @@ void RegionAllocator<T>::capacity(uint32_t min_cap)
         cap += delta;
 
         if (cap <= prev_cap)
-            throw OutOfMemoryException();
+            fatal_out_of_memory();
     }
     //printf(" .. (%p) cap = %u\n", this, cap);
 
@@ -122,7 +122,7 @@ RegionAllocator<T>::alloc(int size)
     
     // Handle overflow:
     if (sz < prev_sz)
-        throw OutOfMemoryException();
+        fatal_out_of_memory();
 
     return prev_sz;
 }

--- a/src/sat/glucose2/Vec.h
+++ b/src/sat/glucose2/Vec.h
@@ -102,14 +102,14 @@ void vec<T>::capacity(int min_cap) {
     if (cap >= min_cap) return;
     int add = imax((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
     if (add > INT_MAX - cap || (((data = (T*)::realloc((void*)data, (cap += add) * sizeof(T))) == NULL) && errno == ENOMEM))
-        throw OutOfMemoryException();
+        fatal_out_of_memory();
  }
 
 template<class T>
 void vec<T>::prelocate(int ext_cap) {
     if (cap >= ext_cap) return;
     if (ext_cap > INT_MAX || (((data = (T*)::realloc((void*)data, ext_cap * sizeof(T))) == NULL) && errno == ENOMEM))
-        throw OutOfMemoryException();
+        fatal_out_of_memory();;
     cap = ext_cap;
  }
 

--- a/src/sat/glucose2/XAlloc.h
+++ b/src/sat/glucose2/XAlloc.h
@@ -34,12 +34,18 @@ namespace Gluco2 {
 //=================================================================================================
 // Simple layer on top of malloc/realloc to catch out-of-memory situtaions and provide some typing:
 
-class OutOfMemoryException{};
+static inline void fatal_out_of_memory()
+{
+    fputs("Out of memory\n", stderr);
+    abort();
+}
+
 static inline void* xrealloc(void *ptr, size_t size)
 {
     void* mem = realloc(ptr, size);
     if (mem == NULL && errno == ENOMEM){
-        throw OutOfMemoryException();
+        fatal_out_of_memory();
+        return NULL;
     }else {
         return mem;
     }


### PR DESCRIPTION
…bort

Many C++ projects forbid the use of exceptions. These are not recoverable errors anyway, so just abort.