### PR TITLE
Fix types in call to atomic_store_explicit

### DIFF
--- a/src/misc/util/utilPth.c
+++ b/src/misc/util/utilPth.c
@@ -103,7 +103,7 @@ void * Util_Thread( void * pArg )
             return NULL;
         }
         pThData->pUserFunc( pThData->pUserData );
-        atomic_store_explicit(&pThData->fWorking, 0, memory_order_release);
+        atomic_store_explicit(&pThData->fWorking, false, memory_order_release);
     }
     assert( 0 );
     return NULL;
@@ -133,7 +133,7 @@ void Util_ProcessThreads( int (*pUserFunc)(void *), void * vData, int nProcs, in
         ThData[i].pUserFunc = pUserFunc;
         ThData[i].iThread   = i;
         ThData[i].nTimeOut  = TimeOut;
-        atomic_store_explicit(&ThData[i].fWorking, 0, memory_order_release);
+        atomic_store_explicit(&ThData[i].fWorking, false, memory_order_release);
         status = pthread_create( WorkerThread + i, NULL, Util_Thread, (void *)(ThData + i) );  assert( status == 0 );
     }
 
@@ -150,7 +150,7 @@ void Util_ProcessThreads( int (*pUserFunc)(void *), void * vData, int nProcs, in
             if ( atomic_load_explicit(&ThData[i].fWorking, memory_order_acquire) )
                 continue;
             ThData[i].pUserData = Vec_PtrPop( vStack );
-            atomic_store_explicit(&ThData[i].fWorking, 1, memory_order_release);
+            atomic_store_explicit(&ThData[i].fWorking, true, memory_order_release);
             break;
         }
     }
@@ -168,7 +168,7 @@ void Util_ProcessThreads( int (*pUserFunc)(void *), void * vData, int nProcs, in
     for ( i = 0; i < nProcs; i++ )
     {
         ThData[i].pUserData = NULL;
-        atomic_store_explicit(&ThData[i].fWorking, 1, memory_order_release);
+        atomic_store_explicit(&ThData[i].fWorking, true, memory_order_release);
     }
 
     // Join threads

--- a/src/misc/util/utilPth.c
+++ b/src/misc/util/utilPth.c
@@ -36,6 +36,7 @@
 using namespace std;
 #else
 #include <stdatomic.h>
+#include <stdbool.h>
 #endif
 
 #endif

--- a/src/proof/ssw/sswPart.c
+++ b/src/proof/ssw/sswPart.c
@@ -126,7 +126,7 @@ void * Ssw_GiaWorkerThread( void * pArg )
             return NULL;
         }
         Cec_ManLSCorrespondenceClasses( pThData->p, &pThData->CorPars );
-        atomic_store_explicit(&pThData->fWorking, 0, memory_order_release);
+        atomic_store_explicit(&pThData->fWorking, false, memory_order_release);
     }
     assert( 0 );
     return NULL;
@@ -154,7 +154,7 @@ void Ssw_SignalCorrespondenceArray( Vec_Ptr_t * vGias, Ssw_Pars_t * pPars )
     {
         ThData[i].CorPars  = *pCorPars;
         ThData[i].iThread  = i;
-        atomic_store_explicit(&ThData[i].fWorking, 0, memory_order_release);
+        atomic_store_explicit(&ThData[i].fWorking, false, memory_order_release);
         status = pthread_create( WorkerThread + i, NULL, Ssw_GiaWorkerThread, (void *)(ThData + i) );  assert( status == 0 );
     }
 
@@ -171,7 +171,7 @@ void Ssw_SignalCorrespondenceArray( Vec_Ptr_t * vGias, Ssw_Pars_t * pPars )
             if ( atomic_load_explicit(&ThData[i].fWorking, memory_order_acquire) )
                 continue;
             ThData[i].p = (Gia_Man_t*)Vec_PtrPop( vStack );
-            atomic_store_explicit(&ThData[i].fWorking, 1, memory_order_release);
+            atomic_store_explicit(&ThData[i].fWorking, true, memory_order_release);
             break;
         }
     }
@@ -188,7 +188,7 @@ void Ssw_SignalCorrespondenceArray( Vec_Ptr_t * vGias, Ssw_Pars_t * pPars )
     for ( i = 0; i < nProcs; i++ )
     {
         ThData[i].p = NULL;
-        atomic_store_explicit(&ThData[i].fWorking, 1, memory_order_release);
+        atomic_store_explicit(&ThData[i].fWorking, true, memory_order_release);
     }
 
     // Join threads

--- a/src/proof/ssw/sswPart.c
+++ b/src/proof/ssw/sswPart.c
@@ -37,6 +37,7 @@
 using namespace std;
 #else
 #include <stdatomic.h>
+#include <stdbool.h>
 #endif
 
 #endif


### PR DESCRIPTION
Deals with the following compilation error:
```
  src/misc/util/utilPth.c:106:9: error: no matching function for call to 'atomic_store_explicit'
          atomic_store_explicit(&pThData->fWorking, 0, memory_order_release);
          ^~~~~~~~~~~~~~~~~~~~~
  ... /include/c++/v1/atomic:1911:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('bool' vs. 'int')
  atomic_store_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
  ^
```