### PR TITLE
Rename Github Actions job to `build-posix-cmake`

### DIFF
--- a/.github/workflows/build-posix-cmake.yml
+++ b/.github/workflows/build-posix-cmake.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  build-posix:
+  build-posix-cmake:
     strategy:
       matrix:
         os: [macos-11, ubuntu-latest]


### PR DESCRIPTION
Clarify that it belongs to the `build-posix-cmake` workflow, not the `build-posix` workflow.