### PR TITLE
Refactor(Resub): Clear markA/B at the beginning

### DIFF
--- a/src/base/abci/abcResub.c
+++ b/src/base/abci/abcResub.c
@@ -170,6 +170,9 @@ int Abc_NtkResubstitute( Abc_Ntk_t * pNtk, int nCutMax, int nStepsMax, int nMinS
     pManRes->nNodesBeg = Abc_NtkNodeNum(pNtk);
     nNodes = Abc_NtkObjNumMax(pNtk);
     pProgress = Extra_ProgressBarStart( stdout, nNodes );
+    //clear markB at the beginning
+    Abc_NtkForEachObj( pNtk, pNode, i )
+        pNode->fMarkB = 0;
     Abc_NtkForEachNode( pNtk, pNode, i )
     {
         Extra_ProgressBarUpdate( pProgress, i, NULL );

--- a/src/base/abci/abcResub.c
+++ b/src/base/abci/abcResub.c
@@ -170,9 +170,8 @@ int Abc_NtkResubstitute( Abc_Ntk_t * pNtk, int nCutMax, int nStepsMax, int nMinS
     pManRes->nNodesBeg = Abc_NtkNodeNum(pNtk);
     nNodes = Abc_NtkObjNumMax(pNtk);
     pProgress = Extra_ProgressBarStart( stdout, nNodes );
-    //clear markB at the beginning
-    Abc_NtkForEachObj( pNtk, pNode, i )
-        pNode->fMarkB = 0;
+    //clear markAB at the beginning
+    Abc_NtkCleanMarkAB( pNtk );
     Abc_NtkForEachNode( pNtk, pNode, i )
     {
         Extra_ProgressBarUpdate( pProgress, i, NULL );


### PR DESCRIPTION
Still working on issue #324 , after adding a verbose log of node name and type, **it turns out it reaches a PI when recursively collecting the node from root (Top-down)**.
After the reconvergence-driven cut process, the leaves should be able to bound the node in the recursive call, but failed in this large case. I checked and think there's possibility if the markB is not cleared at the first place, especially nodes should be added to leaves but skipped due to a markB with value not 0.
In the process of computing cut, markB is manually set to 1, so a clear process is proposed here before all nodes are being processed.