### PR TITLE
Perf improvement in satsolver

### DIFF
--- a/src/sat/bsat/satSolver.c
+++ b/src/sat/bsat/satSolver.c
@@ -60,7 +60,7 @@ static void printlits(lit* begin, lit* end)
 static inline double drand(double* seed) {
     int q;
     *seed *= 1389796;
-    q = (int)(*seed / 2147483647);
+    q = (int)(*seed * 4.6566128752457969e-10); // 1.0/2147483647.0;
     *seed -= (double)q * 2147483647;
     return *seed * 4.6566128752457969e-10; // 1.0/2147483647.0
 }

--- a/src/sat/bsat/satSolver.c
+++ b/src/sat/bsat/satSolver.c
@@ -62,7 +62,8 @@ static inline double drand(double* seed) {
     *seed *= 1389796;
     q = (int)(*seed / 2147483647);
     *seed -= (double)q * 2147483647;
-    return *seed / 2147483647; }
+    return *seed * 4.6566128752457969e-10; // 1.0/2147483647.0
+}
 
 
 // Returns a random integer 0 <= x < size. Seed must never be 0.
@@ -1954,12 +1955,12 @@ int sat_solver_solve_internal(sat_solver* s)
 
     while (status == l_Undef){
         ABC_INT64_T nof_conflicts;
-        double Ratio = (s->stats.learnts == 0)? 0.0 :
-            s->stats.learnts_literals / (double)s->stats.learnts;
         if ( s->nRuntimeLimit && Abc_Clock() > s->nRuntimeLimit )
             break;
         if (s->verbosity >= 1)
         {
+            double Ratio = (s->stats.learnts == 0)? 0.0 :
+                s->stats.learnts_literals / (double)s->stats.learnts;
             printf("| %9.0f | %7.0f %8.0f | %7.0f %7.0f %8.0f %7.1f | %6.3f %% |\n", 
                 (double)s->stats.conflicts,
                 (double)s->stats.clauses, 


### PR DESCRIPTION
This provides a 6% perf improvement on twoexact as measured on my Ampere Altra.

- Switches one FP divide to an FP multiply (variable is constant). 
- Calculate ratio inside of verbosity clause, since that is where it is used (don't compute if you don't have to).