### PR TITLE
Bug(Map): Default value shouldn't be overwritten in USAGE

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -18983,6 +18983,7 @@ int Abc_CommandMap( Abc_Frame_t * pAbc, int argc, char ** argv )
     int fUseBuffs;
     int fVerbose;
     int c;
+    int fDefaultSetting = 0;
     extern Abc_Ntk_t * Abc_NtkMap( Abc_Ntk_t * pNtk, double DelayTarget, double AreaMulti, double DelayMulti, float LogFan, float Slew, float Gain, int nGatesMin, int fRecovery, int fSwitching, int fSkipFanout, int fUseProfile, int fUseBuffs, int fVerbose );
     extern int Abc_NtkFraigSweep( Abc_Ntk_t * pNtk, int fUseInv, int fExdc, int fVerbose, int fVeryVerbose );
 
@@ -19010,10 +19011,13 @@ int Abc_CommandMap( Abc_Frame_t * pAbc, int argc, char ** argv )
                 Abc_Print( -1, "Command line switch \"-D\" should be followed by a floating point number.\n" );
                 goto usage;
             }
+            fDefaultSetting = DelayTarget;
             DelayTarget = (float)atof(argv[globalUtilOptind]);
             globalUtilOptind++;
-            if ( DelayTarget <= 0.0 )
+            if ( DelayTarget <= 0.0 ){
+                DelayTarget = fDefaultSetting;
                 goto usage;
+            }
             break;
         case 'A':
             if ( globalUtilOptind >= argc )
@@ -19039,10 +19043,13 @@ int Abc_CommandMap( Abc_Frame_t * pAbc, int argc, char ** argv )
                 Abc_Print( -1, "Command line switch \"-F\" should be followed by a floating point number.\n" );
                 goto usage;
             }
+            fDefaultSetting = LogFan;
             LogFan = (float)atof(argv[globalUtilOptind]);
             globalUtilOptind++;
-            if ( LogFan < 0.0 )
+            if ( LogFan < 0.0 ){
+                LogFan = fDefaultSetting;
                 goto usage;
+            }
             break;
         case 'S':
             if ( globalUtilOptind >= argc )
@@ -19050,10 +19057,13 @@ int Abc_CommandMap( Abc_Frame_t * pAbc, int argc, char ** argv )
                 Abc_Print( -1, "Command line switch \"-S\" should be followed by a floating point number.\n" );
                 goto usage;
             }
+            fDefaultSetting = Slew;
             Slew = (float)atof(argv[globalUtilOptind]);
             globalUtilOptind++;
-            if ( Slew <= 0.0 )
+            if ( Slew <= 0.0 ){
+                Slew = fDefaultSetting;
                 goto usage;
+            }
             break;
         case 'G':
             if ( globalUtilOptind >= argc )
@@ -19061,10 +19071,13 @@ int Abc_CommandMap( Abc_Frame_t * pAbc, int argc, char ** argv )
                 Abc_Print( -1, "Command line switch \"-G\" should be followed by a floating point number.\n" );
                 goto usage;
             }
+            fDefaultSetting = Gain;
             Gain = (float)atof(argv[globalUtilOptind]);
             globalUtilOptind++;
-            if ( Gain <= 0.0 )
+            if ( Gain <= 0.0 ){
+                Gain = fDefaultSetting;
                 goto usage;
+            }
             break;
         case 'M':
             if ( globalUtilOptind >= argc )
@@ -19072,10 +19085,13 @@ int Abc_CommandMap( Abc_Frame_t * pAbc, int argc, char ** argv )
                 Abc_Print( -1, "Command line switch \"-M\" should be followed by a positive integer.\n" );
                 goto usage;
             }
+            fDefaultSetting = nGatesMin;
             nGatesMin = atoi(argv[globalUtilOptind]);
             globalUtilOptind++;
-            if ( nGatesMin < 0 )
+            if ( nGatesMin < 0 ){
+                nGatesMin = fDefaultSetting;
                 goto usage;
+            }
             break;
         case 'a':
             fAreaOnly ^= 1;


### PR DESCRIPTION
Default value in usage manual shouldn't be changed when **wrong parameter value** is given.
When a wrong value such as -50000 set to Gain, the default value is overwritten by this wrong value:
<pre>
ABC command line: "source -x ./testsplit.script".

abc - > read_aiger i10.aig
abc - > read_lib NangateOpenCellLibrary_typical.lib
Library "NangateOpenCellLibrary" from "NangateOpenCellLibrary_typical.lib" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.04 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").
abc - > strash
abc - > resub -K 6 -N 3
abc - > resub -K 8 -N 3
abc - > resub -K 10 -N 3
abc - > map -G <b>-50000</b>
usage: map [-DABFSG float] [-M num] [-arspfuovh]
                   performs standard cell mapping of the current network
        -D float : sets the global required times [default = not used]
        -A float : "area multiplier" to bias gate selection [default = 0.00]
        -B float : "delay multiplier" to bias gate selection [default = 0.00]
        -F float : the logarithmic fanout delay parameter [default = 0.00]
        -S float : the slew parameter used to generate the library [default = 0.00]
        -G float : the gain parameter used to generate the library [<b>default = -50000.00</b>]
        -M num   : skip gate classes whose size is less than this [default = 0]
        -a       : toggles area-only mapping [default = no]
        -r       : toggles area recovery [default = yes]
        -s       : toggles sweep after mapping [default = no]
        -p       : optimizes power by minimizing switching [default = no]
        -f       : do not use large gates to map high-fanout nodes [default = no]
        -u       : use standard-cell profile [default = no]
        -o       : toggles using buffers to decouple combinational outputs [default = no]
        -v       : toggles verbose output [default = no]
        -h       : print the command usage
** cmd error: aborting 'source ./testsplit.script'
</pre>

<br>A temp variable to save the default value is proposed here.


<pre>
ABC command line: "source -x ./testsplit.script".

abc - > read_aiger i10.aig
abc - > read_lib NangateOpenCellLibrary_typical.lib
Library "NangateOpenCellLibrary" from "NangateOpenCellLibrary_typical.lib" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.04 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").
abc - > strash
abc - > resub -K 6 -N 3
abc - > resub -K 8 -N 3
abc - > resub -K 10 -N 3
abc - > map -G <b>-50000</b>
usage: map [-DABFSG float] [-M num] [-arspfuovh]
                   performs standard cell mapping of the current network
        -D float : sets the global required times [default = not used]
        -A float : "area multiplier" to bias gate selection [default = 0.00]
        -B float : "delay multiplier" to bias gate selection [default = 0.00]
        -F float : the logarithmic fanout delay parameter [default = 0.00]
        -S float : the slew parameter used to generate the library [default = 0.00]
        -G float : the gain parameter used to generate the library [<b>default = 250.00</b>]
        -M num   : skip gate classes whose size is less than this [default = 0]
        -a       : toggles area-only mapping [default = no]
        -r       : toggles area recovery [default = yes]
        -s       : toggles sweep after mapping [default = no]
        -p       : optimizes power by minimizing switching [default = no]
        -f       : do not use large gates to map high-fanout nodes [default = no]
        -u       : use standard-cell profile [default = no]
        -o       : toggles using buffers to decouple combinational outputs [default = no]
        -v       : toggles verbose output [default = no]
        -h       : print the command usage
** cmd error: aborting 'source ./testsplit.script'
</pre>