### PR TITLE
Resolve problems with GitHub Actions

### DIFF
--- a/.github/workflows/build-posix-cmake.yml
+++ b/.github/workflows/build-posix-cmake.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -64,7 +64,7 @@ jobs:
        cp build/abc build/libabc.a staging/
 
     - name: Upload pacakge artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: package
+        name: package-cmake-${{ matrix.os }}-${{ matrix.use_namespace }}
         path: staging/

--- a/.github/workflows/build-posix-cmake.yml
+++ b/.github/workflows/build-posix-cmake.yml
@@ -9,7 +9,7 @@ jobs:
   build-posix-cmake:
     strategy:
       matrix:
-        os: [macos-11, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         use_namespace: [false, true]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-posix.yml
+++ b/.github/workflows/build-posix.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -60,7 +60,7 @@ jobs:
        cp abc libabc.a staging/
 
     - name: Upload pacakge artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: package
+        name: package-posix-${{ matrix.os }}-${{ matrix.use_namespace }}
         path: staging/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -46,7 +46,7 @@ jobs:
        copy UpgradeLog.htm staging/
 
     - name: Upload pacakge artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: package
+        name: package-windows
         path: staging/


### PR DESCRIPTION
* upgrade upload-artifact action to v4 as v1 was deprectated long time go and now removed, and make sure artifact names are distinct as required by the new version.

* upgrade checkout action to v4 as v2 is deprecated

* updated macos runner to macos-latest from macos-11, which is no longer supported