### PR TITLE
ttopt bugfix

### DIFF
--- a/src/aig/gia/giaMinLut.c
+++ b/src/aig/gia/giaMinLut.c
@@ -193,7 +193,7 @@ Gia_Man_t * Vec_WrdReadTest( char * pFileName )
 void Vec_WrdReadText( char * pFileName, Vec_Wrd_t ** pvSimI, Vec_Wrd_t ** pvSimO, int nIns, int nOuts )
 {
     int i, nSize, iLine, nLines, nWords;
-    char pLine[1000];
+    char pLine[2000];
     Vec_Wrd_t * vSimI, * vSimO;
     FILE * pFile = fopen( pFileName, "rb" );
     if ( pFile == NULL )
@@ -214,7 +214,7 @@ void Vec_WrdReadText( char * pFileName, Vec_Wrd_t ** pvSimI, Vec_Wrd_t ** pvSimO
     nWords = (nLines + 63)/64;
     vSimI  = Vec_WrdStart( nIns *nWords );
     vSimO  = Vec_WrdStart( nOuts*nWords );
-    for ( iLine = 0; fgets( pLine, 1000, pFile ); iLine++ )
+    for ( iLine = 0; fgets( pLine, 2000, pFile ); iLine++ )
     {
         for ( i = 0; i < nIns; i++ )
             if ( pLine[nIns-1-i] == '1' )
@@ -233,7 +233,7 @@ void Vec_WrdReadText( char * pFileName, Vec_Wrd_t ** pvSimI, Vec_Wrd_t ** pvSimO
 int Vec_WrdReadText2( char * pFileName, Vec_Wrd_t ** pvSimI )
 {
     int i, nSize, iLine, nLines, nWords, nIns;
-    char pLine[1000];
+    char pLine[2000];
     Vec_Wrd_t * vSimI;
     FILE * pFile = fopen( pFileName, "rb" );
     if ( pFile == NULL )
@@ -241,7 +241,7 @@ int Vec_WrdReadText2( char * pFileName, Vec_Wrd_t ** pvSimI )
         printf( "Cannot open file \"%s\" for reading.\n", pFileName );
         return 0;
     }
-    if ( !fgets(pLine, 1000, pFile) || (nIns = strlen(pLine)-1) < 1 )
+    if ( !fgets(pLine, 2000, pFile) || (nIns = strlen(pLine)-1) < 1 )
     {
         printf( "Cannot find the number of inputs in file \"%s\".\n", pFileName );
         fclose( pFile );
@@ -259,7 +259,7 @@ int Vec_WrdReadText2( char * pFileName, Vec_Wrd_t ** pvSimI )
     nLines = nSize / (nIns + 1);
     nWords = (nLines + 63)/64;
     vSimI  = Vec_WrdStart( nIns *nWords );
-    for ( iLine = 0; fgets( pLine, 1000, pFile ); iLine++ )
+    for ( iLine = 0; fgets( pLine, 2000, pFile ); iLine++ )
     {
         for ( i = 0; i < nIns; i++ )
             if ( pLine[nIns-1-i] == '1' )

--- a/src/aig/gia/giaTtopt.cpp
+++ b/src/aig/gia/giaTtopt.cpp
@@ -1176,6 +1176,17 @@ Gia_Man_t * Gia_ManTtoptCare( Gia_Man_t * p, int nIns, int nOuts, int nRounds, c
     {
         vSupp = Gia_ManCollectSuppNew( p, g, nOuts );
         nInputs = Vec_IntSize( vSupp );
+        if ( nInputs == 0 )
+        {
+            for ( k = 0; k < nOuts; k++ )
+            {
+                pObj = Gia_ManCo( p, g+k );
+                pTruth = Gia_ObjComputeTruthTableCut( p, Gia_ObjFanin0(pObj), vSupp );
+                Gia_ManAppendCo( pNew, pTruth[0] & 1 );
+            }
+            Vec_IntFree( vSupp );
+            continue;
+        }
         Ttopt::TruthTableLevelTSM tt( nInputs, nOuts );
         for ( k = 0; k < nOuts; k++ )
         {


### PR DESCRIPTION
ttopt was crashing when handling constant outputs with empty support.
also, there was a buffer overflow in src/aig/gia/giaMinLut.c when synthesizing a large model.