### PR TITLE
Refactor(MemLeak): MemLeak fix in orchestrate

### DIFF
--- a/src/base/abci/abcOrchestration.c
+++ b/src/base/abci/abcOrchestration.c
@@ -3383,26 +3383,43 @@ clk = Abc_Clock();
 Rwr_ManAddTimeUpdate( pManRwr, Abc_Clock() - clk );
             if ( fCompl ) Dec_GraphComplement( pGraph );
             ops_rwr++;
+            if(pFFormRef != NULL){
+                Dec_GraphFree( pFFormRef );
+            }
+            if(pFFormRes != NULL){
+                Dec_GraphFree( pFFormRes );
+            }
             continue;
         } 
         // if (((! (pManRes->nLastGain < 0)) && (! (pManRes->nLastGain < nGain)) && (! (nGain < pManRef->nLastGain))) || ((! (pManRes->nLastGain < 0)) && (! (pManRes->nLastGain < pManRef->nLastGain)) && (! (pManRef->nLastGain < nGain)))){
         if (((! (pManRes->nLastGain < 0)) && (! (pManRes->nLastGain < nGain)) && (! (pManRes->nLastGain < pManRef->nLastGain)))){
         // update with Resub
-            if ( pFFormRes == NULL )
+            if ( pFFormRes == NULL ) {
+                if (pFFormRef != NULL) {
+                    Dec_GraphFree(pFFormRef);
+                }
                 continue;
+            }
             pManRes->nTotalGain += pManRes->nLastGain;
 clk = Abc_Clock();
             Dec_GraphUpdateNetwork( pNode, pFFormRes, fUpdateLevel, pManRes->nLastGain );
 pManRes->timeNtk += Abc_Clock() - clk;
             Dec_GraphFree( pFFormRes );
             ops_res++;
+            if( pFFormRef != NULL ){
+                Dec_GraphFree( pFFormRef);
+            }
             continue;
         }
         // if (((! (pManRef->nLastGain < 0)) && (! (pManRef->nLastGain < nGain)) && (! (nGain < pManRes->nLastGain))) || ((! (pManRef->nLastGain < 0)) && (! (pManRef->nLastGain < pManRes->nLastGain)) && (! (pManRes->nLastGain < nGain)))){
         if (((! (pManRef->nLastGain < 0)) && (! (pManRef->nLastGain < nGain)) && (! (pManRef->nLastGain < pManRes->nLastGain)))){
         // update with Refactor
-            if ( pFFormRef == NULL )
+            if ( pFFormRef == NULL ) {
+                if( pFFormRes != NULL) {
+                    Dec_GraphFree(pFFormRes);
+                }
                 continue;
+            }
 clk = Abc_Clock();
             if ( !Dec_GraphUpdateNetwork( pNode, pFFormRef, fUpdateLevel, pManRef->nLastGain ) )
                  {
@@ -3413,9 +3430,21 @@ clk = Abc_Clock();
 pManRef->timeNtk += Abc_Clock() - clk;
             Dec_GraphFree( pFFormRef );
             ops_ref++;
+            if(pFFormRes != NULL){
+                Dec_GraphFree( pFFormRes );
+            }
             continue;
         }
-        else{ops_null++; continue;}
+        else{
+            ops_null++;
+            if( pFFormRef != NULL ){
+                Dec_GraphFree( pFFormRef);
+            }
+            if(pFFormRes != NULL){
+                Dec_GraphFree( pFFormRes );
+            }
+            continue;
+        }
     }
 
     /*


### PR DESCRIPTION
Command `orchestrate` has created graph for `resub` and `refactor` but some of the condition misses the free process which causes memory leak, this fix frees each one of the condition.
The fix has been verified by valgrind memcheck.
Before the fix:
```
==52950== Memcheck, a memory error detector
==52950== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==52950== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==52950== Command: ./abc -c read_aiger\ i10.aig;\ strash;\ orchestrate
==52950==
ABC command line: "read_aiger i10.aig; strash; orchestrate".

==52950==
==52950== HEAP SUMMARY:
==52950==     in use at exit: 1,221,712 bytes in 1,717 blocks
==52950==   total heap usage: 699,744 allocs, 698,027 frees, 63,686,720 bytes allocated
==52950==
==52950== 32 bytes in 1 blocks are definitely lost in loss record 1 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0x5D8E76: Dec_GraphCreateConst0 (dec.h:248)
==52950==    by 0x5D8E76: Abc_NodeRefactor_1 (abcOrchestration.c:386)
==52950==    by 0x5E1C37: Abc_NtkOrchLocal (abcOrchestration.c:3345)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== 64 bytes in 2 blocks are definitely lost in loss record 2 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0x5DC48B: Dec_GraphCreateConst0 (dec.h:248)
==52950==    by 0x5DC48B: Abc_ManResubQuit (abcOrchestration.c:1517)
==52950==    by 0x5DC48B: Abc_ManResubEval (abcOrchestration.c:2369)
==52950==    by 0x5E1E10: Abc_NtkOrchLocal (abcOrchestration.c:3363)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== 1,392 bytes in 1 blocks are possibly lost in loss record 3 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0xB47047: Kit_GraphCreate (kitGraph.c:54)
==52950==    by 0xB46C0E: Kit_SopFactor (kitFactor.c:80)
==52950==    by 0xB475F7: Kit_TruthToGraph (kitGraph.c:369)
==52950==    by 0x5D8F63: Abc_NodeRefactor_1 (abcOrchestration.c:389)
==52950==    by 0x5E1C37: Abc_NtkOrchLocal (abcOrchestration.c:3345)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== 38,400 (960 direct, 37,440 indirect) bytes in 30 blocks are definitely lost in loss record 5 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0x5DB004: Dec_GraphCreate (dec.h:224)
==52950==    by 0x5DB004: Abc_ManResubQuit0_1 (abcOrchestration.c:1089)
==52950==    by 0x5DC576: Abc_ManResubDivs0 (abcOrchestration.c:1546)
==52950==    by 0x5DC576: Abc_ManResubEval (abcOrchestration.c:2377)
==52950==    by 0x5E1E10: Abc_NtkOrchLocal (abcOrchestration.c:3363)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== 43,824 (1,056 direct, 42,768 indirect) bytes in 33 blocks are definitely lost in loss record 7 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0x5DB0D0: Dec_GraphCreate (dec.h:224)
==52950==    by 0x5DB0D0: Abc_ManResubQuit1_1 (abcOrchestration.c:1115)
==52950==    by 0x5DCBD8: Abc_ManResubDivs1 (abcOrchestration.c:1606)
==52950==    by 0x5DCBD8: Abc_ManResubEval (abcOrchestration.c:2394)
==52950==    by 0x5E1E10: Abc_NtkOrchLocal (abcOrchestration.c:3363)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== 254,976 (6,144 direct, 248,832 indirect) bytes in 192 blocks are definitely lost in loss record 9 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0x5DB0D0: Dec_GraphCreate (dec.h:224)
==52950==    by 0x5DB0D0: Abc_ManResubQuit1_1 (abcOrchestration.c:1115)
==52950==    by 0x5DCE03: Abc_ManResubDivs1 (abcOrchestration.c:1648)
==52950==    by 0x5DCE03: Abc_ManResubEval (abcOrchestration.c:2394)
==52950==    by 0x5E1E10: Abc_NtkOrchLocal (abcOrchestration.c:3363)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== 883,024 (19,264 direct, 863,760 indirect) bytes in 602 blocks are definitely lost in loss record 11 of 11
==52950==    at 0x4C29F73: malloc (vg_replace_malloc.c:309)
==52950==    by 0xB47011: Kit_GraphCreate (kitGraph.c:49)
==52950==    by 0xB46C0E: Kit_SopFactor (kitFactor.c:80)
==52950==    by 0xB475F7: Kit_TruthToGraph (kitGraph.c:369)
==52950==    by 0x5D8F63: Abc_NodeRefactor_1 (abcOrchestration.c:389)
==52950==    by 0x5E1C37: Abc_NtkOrchLocal (abcOrchestration.c:3345)
==52950==    by 0x50D3A4: Abc_CommandOrchestrate (abc.c:7731)
==52950==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==52950==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==52950==    by 0x6980E0: Abc_RealMain (mainReal.c:332)
==52950==    by 0x6958C4: main (main.c:11)
==52950==
==52950== LEAK SUMMARY:
==52950==    definitely lost: 27,520 bytes in 860 blocks
==52950==    indirectly lost: 1,192,800 bytes in 856 blocks
==52950==      possibly lost: 1,392 bytes in 1 blocks
==52950==    still reachable: 0 bytes in 0 blocks
==52950==         suppressed: 0 bytes in 0 blocks
==52950==
==52950== For lists of detected and suppressed errors, rerun with: -s
==52950== ERROR SUMMARY: 7 errors from 7 contexts (suppressed: 0 from 0)
```


After the fix:
```
==18939== Memcheck, a memory error detector
==18939== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18939== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18939== Command: ./abc -c read_aiger\ i10.aig;\ strash;\ orchestrate
==18939==
ABC command line: "read_aiger i10.aig; strash; orchestrate".

==18939==
==18939== HEAP SUMMARY:
==18939==     in use at exit: 0 bytes in 0 blocks
==18939==   total heap usage: 699,744 allocs, 699,744 frees, 63,686,720 bytes allocated
==18939==
==18939== All heap blocks were freed -- no leaks are possible
==18939==
==18939== For lists of detected and suppressed errors, rerun with: -s
==18939== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```