### PR TITLE
Fix(&put): &put bug with choices

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -32395,7 +32395,7 @@ int Abc_CommandAbc9Put( Abc_Frame_t * pAbc, int argc, char ** argv )
     else
     {
         Abc_Ntk_t * pNtkNoCh;
-        Abc_Print( -1, "Transforming AIG with %d choice nodes.\n", Gia_ManEquivCountClasses(pAbc->pGia) );
+        Abc_Print( 0, "Transforming AIG with %d choice nodes.\n", Gia_ManEquivCountClasses(pAbc->pGia) );
         // create network without choices
         pMan = Gia_ManToAig( pAbc->pGia, 0 );
         pNtkNoCh = Abc_NtkFromAigPhase( pMan );

--- a/src/base/abci/abcDar.c
+++ b/src/base/abci/abcDar.c
@@ -1221,6 +1221,8 @@ Abc_Ntk_t * Abc_NtkFromDarChoices( Abc_Ntk_t * pNtkOld, Aig_Man_t * pMan )
     Aig_ManForEachNode( pMan, pObj, i )
     {
         pObj->pData = Abc_AigAnd( (Abc_Aig_t *)pNtkNew->pManFunc, (Abc_Obj_t *)Aig_ObjChild0Copy(pObj), (Abc_Obj_t *)Aig_ObjChild1Copy(pObj) );
+    }
+    Aig_ManForEachNode( pMan, pObj, i ) {
         if ( (pTemp = Aig_ObjEquiv(pMan, pObj)) )
         {
             assert( pTemp->pData != NULL );


### PR DESCRIPTION
Related: #349

This PR fix the bug when `&put` is used with choice network.
It used to fail on an assert:
```
ABC command line: "read_aiger i10.aig; strash; choice; ps; &get; &ps; &put; ps".

i10                           : i/o =  257/  224  lat =    0  and =   3764 (choice = 541)  lev = 51
i10      : i/o =    257/    224  and =    3764  lev =   51 (16.05)  mem = 0.05 MB
cst =       0  cls =    541  lit =     587  unused =    2893  proof =     0
Error: Transforming AIG with 541 choice nodes.
Assertion failed: (pTemp->pData != NULL), function Abc_NtkFromDarChoices, file abcDar.c, line 1227.
[1]    69583 abort      ./abc -c "read_aiger i10.aig; strash; choice; ps; &get; &ps; &put; ps"
```

After fix (cec checked):
```
ABC command line: "read_aiger i10.aig; strash; choice; ps; &get; &ps; &put; ps; cec -n i10.aig".

i10                           : i/o =  257/  224  lat =    0  and =   3764 (choice = 541)  lev = 51
i10      : i/o =    257/    224  and =    3764  lev =   51 (16.05)  mem = 0.05 MB
cst =       0  cls =    541  lit =     587  unused =    2893  proof =     0
Warning: Transforming AIG with 541 choice nodes.
i10                           : i/o =  257/  224  lat =    0  and =   3764 (choice = 541)  lev = 51
Warning: The choice nodes in the original AIG are removed by strashing.
Networks are equivalent.  Time =     0.32 sec
```
The reason would be some choices are not even created when comparing, so assign the relations after creating the whole network would be good to go.