### PR TITLE
Fix(&if -x): Conditional jump or move depends on uninitialised value(s)

### DIFF
--- a/src/opt/dau/dauMerge.c
+++ b/src/opt/dau/dauMerge.c
@@ -560,7 +560,7 @@ void Dau_DsdRemoveBraces( char * pDsd, int * pMatches )
     for ( q = p; *p; p++ )
         if ( *p != ' ' )
         {
-            if ( *p == '!' && *(q-1) == '!' && p != q )
+            if ( *p == '!' && p != q && *(q-1) == '!' )
             {
                 q--;
                 continue;


### PR DESCRIPTION
Fixed this using a short-circuit by swapping the second and third condition.
Valgrind log, before:
```
ABC command line: "read_aiger i10.aig; strash; &get; &if -x".

==44570== Conditional jump or move depends on uninitialised value(s)
==44570==    at 0x9DEBA1: Dau_DsdRemoveBraces (dauMerge.c:563)
==44570==    by 0x9D1F53: Dau_DsdDecompose (dauDsd.c:1926)
==44570==    by 0x835523: If_DsdManCompute (ifDsd.c:2073)
==44570==    by 0x84177C: If_ObjPerformMappingAnd (ifMap.c:315)
==44570==    by 0x843720: If_ManPerformMappingRound (ifMap.c:667)
==44570==    by 0x813A01: If_ManPerformMappingComb (ifCore.c:126)
==44570==    by 0x813C88: If_ManPerformMapping (ifCore.c:91)
==44570==    by 0xE5F147: Gia_ManPerformMappingInt (giaIf.c:2503)
==44570==    by 0xE60976: Gia_ManPerformMapping (giaIf.c:2566)
==44570==    by 0x543605: Abc_CommandAbc9If (abc.c:41910)
==44570==    by 0x654739: CmdCommandDispatch (cmdUtils.c:157)
==44570==    by 0x64E0F2: Cmd_CommandExecute (cmdApi.c:210)
==44570==
==44570==
==44570== HEAP SUMMARY:
==44570==     in use at exit: 0 bytes in 0 blocks
==44570==   total heap usage: 344,614 allocs, 344,614 frees, 32,395,015 bytes allocated
==44570==
==44570== All heap blocks were freed -- no leaks are possible
==44570==
==44570== Use --track-origins=yes to see where uninitialised values come from
==44570== For lists of detected and suppressed errors, rerun with: -s
==44570== ERROR SUMMARY: 206 errors from 1 contexts (suppressed: 0 from 0)
```
After:
```
ABC command line: "read_aiger i10.aig; strash; &get; &if -x".

==58058==
==58058== HEAP SUMMARY:
==58058==     in use at exit: 0 bytes in 0 blocks
==58058==   total heap usage: 344,614 allocs, 344,614 frees, 32,395,015 bytes allocated
==58058==
==58058== All heap blocks were freed -- no leaks are possible
==58058==
==58058== For lists of detected and suppressed errors, rerun with: -s
==58058== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```