### PR TITLE
cec: Modifying algorithm for generating simulation vectors for SAT sweeping (SimGen) and adding new feature to specify the simulation vector of the PIs for SAT sweeping algorithm.

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -477,7 +477,7 @@ static int Abc_CommandAbc9Scorr              ( Abc_Frame_t * pAbc, int argc, cha
 static int Abc_CommandAbc9Choice             ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int Abc_CommandAbc9Sat                ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int Abc_CommandAbc9SatEnum            ( Abc_Frame_t * pAbc, int argc, char ** argv );
-static int Abc_CommandAbc9SimGen             ( Abc_Frame_t * pAbc, int argc, char ** argv );
+static int Abc_CommandAbc9AdvGenSim             ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int Abc_CommandAbc9Fraig              ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int Abc_CommandAbc9CFraig             ( Abc_Frame_t * pAbc, int argc, char ** argv );
 static int Abc_CommandAbc9Srm                ( Abc_Frame_t * pAbc, int argc, char ** argv );
@@ -1277,7 +1277,7 @@ void Abc_Init( Abc_Frame_t * pAbc )
     Cmd_CommandAdd( pAbc, "ABC9",         "&choice",       Abc_CommandAbc9Choice,       0 );
     Cmd_CommandAdd( pAbc, "ABC9",         "&sat",          Abc_CommandAbc9Sat,          0 );
     Cmd_CommandAdd( pAbc, "ABC9",         "&satenum",      Abc_CommandAbc9SatEnum,      0 );
-    Cmd_CommandAdd( pAbc, "ABC9",         "&fraigSimGen",      Abc_CommandAbc9SimGen,        0 );
+    Cmd_CommandAdd( pAbc, "ABC9",         "&adv_sim_gen",      Abc_CommandAbc9AdvGenSim,        0 );
     Cmd_CommandAdd( pAbc, "ABC9",         "&fraig",        Abc_CommandAbc9Fraig,        0 );
     Cmd_CommandAdd( pAbc, "ABC9",         "&cfraig",       Abc_CommandAbc9CFraig,       0 );
     Cmd_CommandAdd( pAbc, "ABC9",         "&srm",          Abc_CommandAbc9Srm,          0 );
@@ -39179,7 +39179,7 @@ usage:
 
 /**Function*************************************************************
 
-  Synopsis    [Abc_CommandAbc9SimGen]
+  Synopsis    [Abc_CommandAbc9AdvGenSim]
 
   Description [This function calls SimGen tool]
 
@@ -39189,7 +39189,7 @@ usage:
 
 ***********************************************************************/
 
-int Abc_CommandAbc9SimGen( Abc_Frame_t * pAbc, int argc, char ** argv )
+int Abc_CommandAbc9AdvGenSim( Abc_Frame_t * pAbc, int argc, char ** argv )
 {
     extern void Cec_SimGenSetParDefault( Cec_ParSimGen_t * pPars );
     extern Gia_Man_t * Cec_SimGenRun( Gia_Man_t * pAig, Cec_ParSimGen_t * pPars );
@@ -39198,7 +39198,7 @@ int Abc_CommandAbc9SimGen( Abc_Frame_t * pAbc, int argc, char ** argv )
     int c;
     Cec_SimGenSetParDefault( pPars );
     Extra_UtilGetoptReset();
-    while ( ( c = Extra_UtilGetopt( argc, argv, "EOStiwvV" ) ) != EOF )
+    while ( ( c = Extra_UtilGetopt( argc, argv, "EOStiFwvV" ) ) != EOF )
     {
         switch ( c )
         {
@@ -39257,6 +39257,15 @@ int Abc_CommandAbc9SimGen( Abc_Frame_t * pAbc, int argc, char ** argv )
             if ( pPars->nMaxIter <= -2 )
                 goto usage;
             break;
+        case 'F':
+            if ( globalUtilOptind >= argc )
+            {
+                Abc_Print( -1, "Command line switch \"-F\" should be followed by a string.\n" );
+                goto usage;
+            }
+            pPars->pFileName = argv[globalUtilOptind];
+            globalUtilOptind++;
+            break;  
         case 'w':
             pPars->fUseWatchlist = 1;
             break;
@@ -39287,13 +39296,14 @@ int Abc_CommandAbc9SimGen( Abc_Frame_t * pAbc, int argc, char ** argv )
     return 0;
 
 usage:
-    Abc_Print( -2, "usage: &fraigSimGen [-EOSsivV <num>] [-v] \n" );
-    Abc_Print( -2, "\t         performs combinational SAT sweeping applying SimGen\n" );
-    Abc_Print( -2, "\t-E num : the experiment ID for SimGen [default = %d]\n", pPars->expId );
+    Abc_Print( -2, "usage: &adv_sim_gen [-EOSsivV <num>] [-v] \n" );
+    Abc_Print( -2, "\t         generates simulation patterns for combinational SAT sweeping\n" );
+    Abc_Print( -2, "\t-E num : the experiment ID for different techniques [default = %d]\n", pPars->expId );
     Abc_Print( -2, "\t-O num : the bitwidth of the output gold [default = %d]\n", pPars->bitwidthOutgold );
-    Abc_Print( -2, "\t-S num : the bitwidth of the simulation vectors [default = %d]\n", pPars->bitwidthSim );
-    Abc_Print( -2, "\t-t num : the timeout value after which Smart Simulation Pattern Generation terminates [default = %.0f]\n", pPars->timeOutSim);
+    Abc_Print( -2, "\t-S num : the bitwidth of the simulation vectors for random simulation [default = %d]\n", pPars->bitwidthSim );
+    Abc_Print( -2, "\t-t num : the timeout value [default = %.0f]\n", pPars->timeOutSim);
     Abc_Print( -2, "\t-i num : the maximum number of iterations [default = %d]\n", pPars->nMaxIter );
+    Abc_Print( -2, "\t-F file: the file name to dump the generated patterns  [default = none]\n");
     Abc_Print( -2, "\t-w     : activates the watchlist feature [default = %d]\n", pPars->fUseWatchlist);
     Abc_Print( -2, "\t-v     : verbose [default = %d]\n", pPars->fVerbose );
     Abc_Print( -2, "\t-V     : very verbose [default = %d]\n", pPars->fVeryVerbose );

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -39230,9 +39230,9 @@ int Abc_CommandAbc9AdvGenSim( Abc_Frame_t * pAbc, int argc, char ** argv )
                 Abc_Print( -1, "Command line switch \"-S\" should be followed by an integer.\n" );
                 goto usage;
             }
-            pPars->bitwidthSim = atoi(argv[globalUtilOptind]);
+            pPars->nSimWords = atoi(argv[globalUtilOptind]);
             globalUtilOptind++;
-            if ( pPars->bitwidthSim <= 0 )
+            if ( pPars->nSimWords <= 0 )
                 goto usage;
             break;
         case 't':
@@ -39300,9 +39300,9 @@ usage:
     Abc_Print( -2, "\t         generates simulation patterns for combinational SAT sweeping\n" );
     Abc_Print( -2, "\t-E num : the experiment ID for different techniques [default = %d]\n", pPars->expId );
     Abc_Print( -2, "\t-O num : the bitwidth of the output gold [default = %d]\n", pPars->bitwidthOutgold );
-    Abc_Print( -2, "\t-S num : the bitwidth of the simulation vectors for random simulation [default = %d]\n", pPars->bitwidthSim );
+    Abc_Print( -2, "\t-S num : the number of words in a round for random simulation [default = %d]\n", pPars->nSimWords );
     Abc_Print( -2, "\t-t num : the timeout value [default = %.0f]\n", pPars->timeOutSim);
-    Abc_Print( -2, "\t-i num : the maximum number of iterations [default = %d]\n", pPars->nMaxIter );
+    Abc_Print( -2, "\t-i num : the number of rounds of random simulation [default = %d]\n", pPars->nMaxIter );
     Abc_Print( -2, "\t-F file: the file name to dump the generated patterns  [default = none]\n");
     Abc_Print( -2, "\t-w     : activates the watchlist feature [default = %d]\n", pPars->fUseWatchlist);
     Abc_Print( -2, "\t-v     : verbose [default = %d]\n", pPars->fVerbose );

--- a/src/proof/cec/cec.h
+++ b/src/proof/cec/cec.h
@@ -209,8 +209,8 @@ struct Cec_ParSimGen_t_
     int              fVeryVerbose;      // verbose flag
     int              expId;             // experiment ID for SimGen
     int              bitwidthOutgold;   // bitwidth of the output gold
-    int              bitwidthSim;       // bitwidth of the simulation vectors
-    int              nMaxIter;          // maximum number of iterations
+    int              nSimWords;       // number of words in a round of random simulation
+    int              nMaxIter;          // maximum number of rounds of random simulation
     char *           outGold;           // data containing outgold
     float            timeOutSim;        // timeout for simulation
     int              fUseWatchlist;     // use watchlist

--- a/src/proof/cec/cec.h
+++ b/src/proof/cec/cec.h
@@ -219,7 +219,6 @@ struct Cec_ParSimGen_t_
     int              nImplicationSuccess; // number of times implication was successful
     int              nImplicationTotalChecks; // number of times implication was checked
     int              nImplicationSuccessChecks; // number of times implication was successful
-    Cec_ParFra_t *   pCECPars;             // parameters of CEC   
     char *           pFileName;         // file name to dump simulation vectors
 };
 

--- a/src/proof/cec/cec.h
+++ b/src/proof/cec/cec.h
@@ -220,6 +220,7 @@ struct Cec_ParSimGen_t_
     int              nImplicationTotalChecks; // number of times implication was checked
     int              nImplicationSuccessChecks; // number of times implication was successful
     Cec_ParFra_t *   pCECPars;             // parameters of CEC   
+    char *           pFileName;         // file name to dump simulation vectors
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/proof/cec/cecSatG2.c
+++ b/src/proof/cec/cecSatG2.c
@@ -4476,9 +4476,6 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
       Vec_WrdDumpHex( pPars->pFileName, p->vSimsPi, nWordsPerCi , 1 );
     }
 
-    if (pPars->fVerbose || pPars->fVeryVerbose){
-        pManSim->pPars->fVerbose = 1; // print the ending stats of sat calls
-    }
     // free memory
     Vec_IntFree( pMapped->vTTLut );
     Vec_StrFree( pMapped->vTTISOPs );

--- a/src/proof/cec/cecSatG2.c
+++ b/src/proof/cec/cecSatG2.c
@@ -4377,6 +4377,7 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
         printf("Using already mapped network\n");
     }
     pCECPars = (Cec_ParFra_t *) malloc(sizeof( Cec_ParFra_t )); // parameters of CEC
+    pManSim->pPars->fVerbose = 0; // disabling verbose sat solver
     pManSim = Cec4_ManCreate( pMapped, pCECPars );
 
     Cec_DeriveSOPs( pMapped );

--- a/src/proof/cec/cecSatG2.c
+++ b/src/proof/cec/cecSatG2.c
@@ -2959,7 +2959,7 @@ void saveSimVectors( Gia_Man_t * p, Vec_Ptr_t * pValues, int bitLength, int jth_
     int nWords = bitLength / 64;
     assert(nWords == 0); // Not considering case with large outgold values
     Gia_ManForEachCiId( p, Id, i ){
-        Vec_Wrd_t * pValuesPi = Vec_PtrEntry( pValues, i );
+        Vec_Wrd_t * pValuesPi = (Vec_Wrd_t *) Vec_PtrEntry( pValues, i );
         word pValuePiJWord = 0;
         if(kth_bit == 0){
           Vec_WrdPush( pValuesPi, 0 );
@@ -3002,7 +3002,7 @@ void executeRandomSim( Gia_Man_t * p, Cec4_Man_t * pMan , int dynSim, int nMaxIt
       numClass = totalNumClasses(p);
       iNumber++;
       Gia_ManForEachCiId( p, Id, j ){
-        Vec_Wrd_t * vSimPI = Vec_PtrEntry( vSimSave, j );
+        Vec_Wrd_t * vSimPI = (Vec_Wrd_t *) Vec_PtrEntry( vSimSave, j );
         word * pSim = Cec4_ObjSim( p, Id );
         for( k = 0; k < p->nSimWords; k++ ){
           Vec_WrdPush( vSimPI, pSim[k] );
@@ -3020,7 +3020,7 @@ void executeRandomSim( Gia_Man_t * p, Cec4_Man_t * pMan , int dynSim, int nMaxIt
       if (verbose)
         printf("Time elapsed: %f (classes size: %d)\n", (float)(clock() - start_time)/CLOCKS_PER_SEC, quality);
       Gia_ManForEachCiId( p, Id, j ){
-        Vec_Wrd_t * vSimPI = Vec_PtrEntry( vSimSave, j );
+        Vec_Wrd_t * vSimPI = (Vec_Wrd_t *) Vec_PtrEntry( vSimSave, j );
         word * pSim = Cec4_ObjSim( p, Id );
         for( k = 0; k < p->nSimWords; k++ ){
           Vec_WrdPush( vSimPI, pSim[k] );
@@ -4357,7 +4357,7 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
 
     extern void Gia_ManDupMapping( Gia_Man_t * pNew, Gia_Man_t * p );
     Cec4_Man_t * pManSim;  
-    int i, k, iFan, nWordsPerCi;
+    int i, k, nWordsPerCi;
     Gia_Man_t * pMapped;
     Vec_Ptr_t * vSimPisSave;
     Cec_ParFra_t * pCECPars;

--- a/src/proof/cec/cecSatG2.c
+++ b/src/proof/cec/cecSatG2.c
@@ -4476,14 +4476,6 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
       Vec_WrdDumpHex( pPars->pFileName, p->vSimsPi, nWordsPerCi , 1 );
     }
 
-    // call SAT solver
-    /*
-    Cec4_CallSATsolver(pMapped, pManSim, pPars->pCECPars);
-    Gia_Man_t * ppNew; Gia_Obj_t * pObj;
-    Gia_ManForEachCo( pMapped, pObj, i )
-            pObj->Value = Gia_ManAppendCo( pManSim->pNew, Gia_ObjFanin0Copy(pObj) );
-        ppNew = Gia_ManCleanup( pManSim->pNew );
-    */
     if (pPars->fVerbose || pPars->fVeryVerbose){
         pManSim->pPars->fVerbose = 1; // print the ending stats of sat calls
     }

--- a/src/proof/cec/cecSatG2.c
+++ b/src/proof/cec/cecSatG2.c
@@ -254,6 +254,7 @@ void Cec_SimGenSetParDefault( Cec_ParSimGen_t * pPars )
     pPars->nImplicationSuccessChecks = 0; // the number of implication successful checks
     pPars->pCECPars             = (Cec_ParFra_t *) malloc(sizeof( Cec_ParFra_t )); // parameters of CEC
     Cec4_ManSetParams( pPars->pCECPars );
+    pPars->pFileName            = NULL; // file name to dump simulation vectors
 }
 
 /**Function*************************************************************
@@ -4380,6 +4381,7 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
 
     Cec_DeriveSOPs( pMapped );
 
+    /*
     if (pPars->fVeryVerbose)
     {    
       printf("**Printing LUTs information**\n");
@@ -4391,6 +4393,7 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
         printISOPLUT( pMapped, i );
       }
     }
+    */
 
     // compute MFFCs
     Gia_ManLevelNum( pMapped); // compute levels
@@ -4469,7 +4472,9 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
     }
     p->nSimWords = nWordsPerCi;
 
-    //Vec_WrdDumpHex( "sim_vec.out", p->vSimsPi, nWordsPerCi , 1 );
+    if (pPars->pFileName != NULL){
+      Vec_WrdDumpHex( pPars->pFileName, p->vSimsPi, nWordsPerCi , 1 );
+    }
 
     // call SAT solver
     /*

--- a/src/proof/cec/cecSatG2.c
+++ b/src/proof/cec/cecSatG2.c
@@ -252,8 +252,6 @@ void Cec_SimGenSetParDefault( Cec_ParSimGen_t * pPars )
     pPars->nImplicationSuccess   = 0; // the number of implication successes
     pPars->nImplicationTotalChecks = 0; // the number of implication checks
     pPars->nImplicationSuccessChecks = 0; // the number of implication successful checks
-    pPars->pCECPars             = (Cec_ParFra_t *) malloc(sizeof( Cec_ParFra_t )); // parameters of CEC
-    Cec4_ManSetParams( pPars->pCECPars );
     pPars->pFileName            = NULL; // file name to dump simulation vectors
 }
 
@@ -4362,6 +4360,7 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
     int i, k, iFan, nWordsPerCi;
     Gia_Man_t * pMapped;
     Vec_Ptr_t * vSimPisSave;
+    Cec_ParFra_t * pCECPars;
 
     if (!Gia_ManHasMapping(p)){
       // apply technology mapping if not already done
@@ -4377,7 +4376,8 @@ Gia_Man_t * Cec_SimGenRun( Gia_Man_t * p, Cec_ParSimGen_t * pPars ){
       if(pPars->fVerbose)
         printf("Using already mapped network\n");
     }
-    pManSim = Cec4_ManCreate( pMapped, pPars->pCECPars );
+    pCECPars = (Cec_ParFra_t *) malloc(sizeof( Cec_ParFra_t )); // parameters of CEC
+    pManSim = Cec4_ManCreate( pMapped, pCECPars );
 
     Cec_DeriveSOPs( pMapped );
 


### PR DESCRIPTION
## Overview
The following pull request modifies the algorithm to generate simulation patterns and adds a new feature in the SAT sweeping algorithm to specify the input vector simulation. 


## Simulation Pattern Generation

The previous command `&fraigSimGen` has been updated to `&adv_sim_gen`. The primary changes include removing the SAT sweeping algorithm and adding a feature to store the generated simulation vector in the GIA class's vSimsPi data structure. Additionally, the CLI option `-S` now specifies the number of words in the random simulation, replacing its previous interpretation as the bitwidth of the simulation. There is also a new CLI option `-F` to specify the filename where to save the generated input vectors. 

## SAT Sweeping New Feature

The new feature in the SAT sweeping algorithm `X` allows specifying the PI vector for simulation by setting the vSimsPi data structure.