### PR TITLE
Feat(write_hmetis): Enable hMetis format

### DIFF
--- a/abclib.dsp
+++ b/abclib.dsp
@@ -691,6 +691,10 @@ SOURCE=.\src\base\io\ioWriteGml.c
 # End Source File
 # Begin Source File
 
+SOURCE=.\src\base\io\ioWriteHMetis.c
+# End Source File
+# Begin Source File
+
 SOURCE=.\src\base\io\ioWriteList.c
 # End Source File
 # Begin Source File

--- a/src/base/io/io.c
+++ b/src/base/io/io.c
@@ -3416,17 +3416,22 @@ int IoCommandWriteHMetis( Abc_Frame_t * pAbc, int argc, char **argv )
     char * pFileName;
     int fVerbose;
     int fSkipPo;
+    int fWeightEdges;
     int c;
 
     fSkipPo       = 1;
+    fWeightEdges  = 0;
     fVerbose      = 0;
     Extra_UtilGetoptReset();
-    while ( ( c = Extra_UtilGetopt( argc, argv, "svh" ) ) != EOF )
+    while ( ( c = Extra_UtilGetopt( argc, argv, "swvh" ) ) != EOF )
     {
         switch ( c )
         {
             case 's':
                 fSkipPo ^= 1;
+                break;
+            case 'w':
+                fWeightEdges ^= 1;
                 break;
             case 'v':
                 fVerbose ^= 1;
@@ -3452,14 +3457,14 @@ int IoCommandWriteHMetis( Abc_Frame_t * pAbc, int argc, char **argv )
         fprintf( stdout, "Writing this format is only possible for structurally hashed AIGs.\n" );
         return 1;
     }
-    //Io_WriteAiger( pAbc->pNtkCur, pFileName, fWriteSymbols, fCompact, fUnique );
-    Io_WriteHMetis( pAbc->pNtkCur, pFileName, fSkipPo, fVerbose );
+    Io_WriteHMetis( pAbc->pNtkCur, pFileName, fSkipPo, fWeightEdges, fVerbose );
     return 0;
 
 usage:
     fprintf( pAbc->Err, "usage: write_hmetis <file>\n" );
     fprintf( pAbc->Err, "\t         writes the network in the hMetis format (https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf)\n" );
     fprintf( pAbc->Err, "\t-s     : skip PO as sink explictly [default = %s]\n", fSkipPo? "yes" : "no" );
+    fprintf( pAbc->Err, "\t-w     : simulate weight on hyperedges [default = %s]\n", fWeightEdges? "yes" : "no" );
     fprintf( pAbc->Err, "\t-v     : toggle printing verbose information [default = %s]\n", fVerbose? "yes" : "no" );
     fprintf( pAbc->Err, "\t-h     : print the help massage\n" );
     fprintf( pAbc->Err, "\tfile   : the name of the file to write\n" );

--- a/src/base/io/io.c
+++ b/src/base/io/io.c
@@ -79,6 +79,7 @@ static int IoCommandWriteCex    ( Abc_Frame_t * pAbc, int argc, char **argv );
 static int IoCommandWriteDot    ( Abc_Frame_t * pAbc, int argc, char **argv );
 static int IoCommandWriteEqn    ( Abc_Frame_t * pAbc, int argc, char **argv );
 static int IoCommandWriteGml    ( Abc_Frame_t * pAbc, int argc, char **argv );
+static int IoCommandWriteHMetis ( Abc_Frame_t * pAbc, int argc, char **argv );
 static int IoCommandWriteList   ( Abc_Frame_t * pAbc, int argc, char **argv );
 static int IoCommandWritePla    ( Abc_Frame_t * pAbc, int argc, char **argv );
 static int IoCommandWriteVerilog( Abc_Frame_t * pAbc, int argc, char **argv );
@@ -155,6 +156,7 @@ void Io_Init( Abc_Frame_t * pAbc )
     Cmd_CommandAdd( pAbc, "I/O", "write_edgelist",IoCommandWriteEdgelist,    0 );
     Cmd_CommandAdd( pAbc, "I/O", "write_gml",     IoCommandWriteGml,     0 );
 //    Cmd_CommandAdd( pAbc, "I/O", "write_list",    IoCommandWriteList,    0 );
+    Cmd_CommandAdd( pAbc, "I/O", "write_hmetis",  IoCommandWriteHMetis,     0 );
     Cmd_CommandAdd( pAbc, "I/O", "write_pla",     IoCommandWritePla,     0 );
     Cmd_CommandAdd( pAbc, "I/O", "write_verilog", IoCommandWriteVerilog, 0 );
 //    Cmd_CommandAdd( pAbc, "I/O", "write_verlib",  IoCommandWriteVerLib,  0 );
@@ -3394,6 +3396,73 @@ usage:
     fprintf( pAbc->Err, "\t-N     : toggle keeping original naming of the netlist in edgelist (default=False)\n");  
     fprintf( pAbc->Err, "\t-h     : print the help massage\n" );
     fprintf( pAbc->Err, "\tfile   : the name of the file to write (extension .el)\n" );
+    return 1;
+}
+
+
+/**Function*************************************************************
+
+  Synopsis    []
+
+  Description []
+               
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int IoCommandWriteHMetis( Abc_Frame_t * pAbc, int argc, char **argv )
+{
+    char * pFileName;
+    int fVerbose;
+    int fSkipPo;
+    int c;
+
+    fSkipPo       = 1;
+    fVerbose      = 0;
+    Extra_UtilGetoptReset();
+    while ( ( c = Extra_UtilGetopt( argc, argv, "svh" ) ) != EOF )
+    {
+        switch ( c )
+        {
+            case 's':
+                fSkipPo ^= 1;
+                break;
+            case 'v':
+                fVerbose ^= 1;
+                break;
+            case 'h':
+                goto usage;
+            default:
+                goto usage;
+        }
+    }
+    if ( pAbc->pNtkCur == NULL )
+    {
+        fprintf( pAbc->Out, "Empty network.\n" );
+        return 0;
+    }
+    if ( argc != globalUtilOptind + 1 )
+        goto usage;
+    // get the output file name
+    pFileName = argv[globalUtilOptind];
+    // call the corresponding file writer
+    if ( !Abc_NtkIsStrash(pAbc->pNtkCur) )
+    {
+        fprintf( stdout, "Writing this format is only possible for structurally hashed AIGs.\n" );
+        return 1;
+    }
+    //Io_WriteAiger( pAbc->pNtkCur, pFileName, fWriteSymbols, fCompact, fUnique );
+    Io_WriteHMetis( pAbc->pNtkCur, pFileName, fSkipPo, fVerbose );
+    return 0;
+
+usage:
+    fprintf( pAbc->Err, "usage: write_hmetis <file>\n" );
+    fprintf( pAbc->Err, "\t         writes the network in the hMetis format (https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf)\n" );
+    fprintf( pAbc->Err, "\t-s     : skip PO as sink explictly [default = %s]\n", fSkipPo? "yes" : "no" );
+    fprintf( pAbc->Err, "\t-v     : toggle printing verbose information [default = %s]\n", fVerbose? "yes" : "no" );
+    fprintf( pAbc->Err, "\t-h     : print the help massage\n" );
+    fprintf( pAbc->Err, "\tfile   : the name of the file to write\n" );
     return 1;
 }
 

--- a/src/base/io/ioAbc.h
+++ b/src/base/io/ioAbc.h
@@ -57,7 +57,8 @@ typedef enum {
     IO_FILE_DOT,      
     IO_FILE_EDIF,      
     IO_FILE_EQN,      
-    IO_FILE_GML,      
+    IO_FILE_GML,
+    IO_FILE_HMETIS,      
     IO_FILE_JSON,      
     IO_FILE_LIST,      
     IO_FILE_PLA,      
@@ -129,6 +130,8 @@ extern void               Io_WriteEqn( Abc_Ntk_t * pNtk, char * pFileName );
 extern void               Io_WriteEdgelist( Abc_Ntk_t * pNtk, char * pFileName, int fWriteLatches, int fBb2Wb, int fSeq , int fName);
 /*=== abcWriteGml.c ===========================================================*/
 extern void               Io_WriteGml( Abc_Ntk_t * pNtk, char * pFileName );
+/*=== abcWriteHMetis.c ===========================================================*/
+extern void               Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbose );
 /*=== abcWriteList.c ==========================================================*/
 extern void               Io_WriteList( Abc_Ntk_t * pNtk, char * pFileName, int fUseHost );
 /*=== abcWritePla.c ===========================================================*/

--- a/src/base/io/ioAbc.h
+++ b/src/base/io/ioAbc.h
@@ -131,7 +131,7 @@ extern void               Io_WriteEdgelist( Abc_Ntk_t * pNtk, char * pFileName, 
 /*=== abcWriteGml.c ===========================================================*/
 extern void               Io_WriteGml( Abc_Ntk_t * pNtk, char * pFileName );
 /*=== abcWriteHMetis.c ===========================================================*/
-extern void               Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbose );
+extern void               Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fWeightEdges, int fVerbose );
 /*=== abcWriteList.c ==========================================================*/
 extern void               Io_WriteList( Abc_Ntk_t * pNtk, char * pFileName, int fUseHost );
 /*=== abcWritePla.c ===========================================================*/

--- a/src/base/io/ioWriteHMetis.c
+++ b/src/base/io/ioWriteHMetis.c
@@ -23,76 +23,89 @@ Minnesota(https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf)]
 
 ABC_NAMESPACE_IMPL_START
 
-void Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbose )
+void Io_WriteHMetis( Abc_Ntk_t *pNtk, char *pFileName, int fSkipPo, int fWeightEdges, int fVerbose )
 {
-    Abc_Obj_t * pObj;
-    Abc_Obj_t * pFanout;
+    Abc_Obj_t *pObj;
+    Abc_Obj_t *pFanout;
     int i, j;
-    Vec_Int_t * vHyperEdgeEachWrite;
-    int Entry;
+    Vec_Int_t *vHyperEdgeEachWrite;
+    int iEntry;
+    int nHyperNodesNum = 0;
     // check that the network is valid
-    assert( Abc_NtkIsStrash( pNtk ) && Abc_NtkIsComb( pNtk ));
-    
-    FILE * pFHMetis = fopen( pFileName, "wb" );
-    Vec_Ptr_t * vHyperEdges = Vec_PtrAlloc(1000);
+    assert( Abc_NtkIsStrash( pNtk ) && Abc_NtkIsComb( pNtk ) );
+
+    FILE *pFHMetis = fopen( pFileName, "wb" );
+    Vec_Ptr_t *vHyperEdges = Vec_PtrAlloc( 1000 );
     if ( pFHMetis == NULL )
     {
         fprintf( stdout, "Io_WriteHMetis(): Cannot open the output file \"%s\".\n", pFileName );
-        ABC_FREE(pFHMetis);
+        ABC_FREE( pFHMetis );
         return;
     }
-    
-    //show pi/po/and number
+
+    // show pi/po/and number
     if ( fVerbose )
     {
-        Abc_Print( 1, "Writing hMetis file \"%s\" with %d nodes (%d pi, %d po, %d and nodes).\n", pFileName, Abc_NtkObjNum(pNtk), Abc_NtkPiNum(pNtk), Abc_NtkPoNum(pNtk), Abc_NtkNodeNum(pNtk) );
+        Abc_Print( 1, "Writing hMetis file \"%s\" with %d nodes (%d pi, %d po, %d and nodes).\n", pFileName, Abc_NtkObjNum( pNtk ), Abc_NtkPiNum( pNtk ), Abc_NtkPoNum( pNtk ), Abc_NtkNodeNum( pNtk ) );
     }
-    
+
     Abc_NtkForEachObj( pNtk, pObj, i )
     {
-        Vec_Int_t * vHyperEdgeEach = Vec_IntAlloc(20);
-        //push the node itself, which is a source node
-        Vec_IntPush(vHyperEdgeEach, Abc_ObjId(pObj));
-        //iterate through all the fanouts(sink) of the node
-        if( !Abc_ObjIsCo(pObj) )
+        Vec_Int_t *vHyperEdgeEach = Vec_IntAlloc( 20 );
+        // push the node itself, which is a source node
+        Vec_IntPush( vHyperEdgeEach, Abc_ObjId( pObj ) );
+        // iterate through all the fanouts(sink) of the node
+        if ( !Abc_ObjIsCo( pObj ) )
         {
-            Abc_ObjForEachFanout(pObj, pFanout, j)
+            Abc_ObjForEachFanout( pObj, pFanout, j )
             {
-                Vec_IntPush(vHyperEdgeEach, Abc_ObjId(pFanout));
+                Vec_IntPush( vHyperEdgeEach, Abc_ObjId( pFanout ) );
             }
-        }
-        else{
+        } else
+        {
             if ( fSkipPo )
             {
                 continue;
             }
-            Vec_IntPush(vHyperEdgeEach, Abc_ObjId(Abc_ObjFanin0(pObj)));
+            Vec_IntPush( vHyperEdgeEach, Abc_ObjId( Abc_ObjFanin0( pObj ) ) );
         }
-        Vec_PtrPush(vHyperEdges, vHyperEdgeEach); 
+        Vec_PtrPush( vHyperEdges, vHyperEdgeEach );
     }
     
-    //write the number of hyperedges and the number of vertices
-    fprintf(pFHMetis, "%d %d\n", Vec_PtrSize(vHyperEdges), Abc_NtkObjNum(pNtk));
-    //write the hyperedges
-    Vec_PtrForEachEntry(Vec_Int_t *, vHyperEdges, vHyperEdgeEachWrite, i)
+    nHyperNodesNum = fSkipPo ? Abc_NtkObjNum( pNtk ) - Abc_NtkPoNum( pNtk ) : Abc_NtkObjNum( pNtk );
+
+    // write the number of hyperedges and the number of vertices
+    if ( fWeightEdges )
     {
-        Vec_IntForEachEntry(vHyperEdgeEachWrite, Entry, j)
-        {   
-            if (j == Vec_IntSize(vHyperEdgeEachWrite) - 1)
-            {
-                fprintf(pFHMetis, "%d", Entry);
-            }
-            else
-            {
-                fprintf(pFHMetis, "%d ", Entry);     
-            }           
-        }
-        fprintf(pFHMetis, "\n");
+        fprintf( pFHMetis, "%d %d 1\n", Vec_PtrSize( vHyperEdges ), nHyperNodesNum );
+    } else
+    {
+        fprintf( pFHMetis, "%d %d\n", Vec_PtrSize( vHyperEdges ), nHyperNodesNum );
     }
-    //comments should be started with "%" in hMetis format
+    // write the hyperedges
+    Vec_PtrForEachEntry( Vec_Int_t *, vHyperEdges, vHyperEdgeEachWrite, i )
+    {
+        if ( fWeightEdges )
+        {
+            fprintf( pFHMetis, "%d ", Vec_IntSize( vHyperEdgeEachWrite ) );
+        }
+
+        Vec_IntForEachEntry( vHyperEdgeEachWrite, iEntry, j )
+        {
+            if ( j == Vec_IntSize( vHyperEdgeEachWrite ) - 1 )
+            {
+                fprintf( pFHMetis, "%d", iEntry );
+            } else
+            {
+                fprintf( pFHMetis, "%d ", iEntry );
+            }
+        }
+        fprintf( pFHMetis, "\n" );
+    }
+    // comments should be started with "%" in hMetis format
     fprintf( pFHMetis, "\n%%This file was written by ABC on %s\n", Extra_TimeStamp() );
     fprintf( pFHMetis, "%%For information about hMetis format, refer to %s\n", "https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf" );
-    Vec_PtrFreeFree(vHyperEdges);
+    Vec_PtrFreeFree( vHyperEdges );
 }
 
 ABC_NAMESPACE_IMPL_END

--- a/src/base/io/ioWriteHMetis.c
+++ b/src/base/io/ioWriteHMetis.c
@@ -19,15 +19,11 @@ Minnesota(https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf)]
   Revision    []
 
 ***********************************************************************/
-#include "base/abc/abc.h"
 #include "ioAbc.h"
-#include "misc/vec/vecInt.h"
-#include "misc/vec/vecPtr.h"
-
 
 ABC_NAMESPACE_IMPL_START
 
-void Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbose)
+void Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbose )
 {
     Abc_Obj_t * pObj;
     Abc_Obj_t * pFanout;

--- a/src/base/io/ioWriteHMetis.c
+++ b/src/base/io/ioWriteHMetis.c
@@ -1,0 +1,101 @@
+/**CFile****************************************************************
+
+  FileName    [ioWriteHMetis.c]
+
+  SystemName  [ABC: Logic synthesis and verification system.]
+
+  PackageName [Command processing package.]
+
+  Synopsis    [Procedures to write hMetis format developed by
+  George Karypis and Vipin Kumar from the University of
+Minnesota(https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf)]
+
+  Author      [Jingren Wang]
+
+  Affiliation []
+
+  Date        [Ver. 1.0. Started - December 16, 2006.]
+
+  Revision    []
+
+***********************************************************************/
+#include "base/abc/abc.h"
+#include "ioAbc.h"
+#include "misc/vec/vecInt.h"
+#include "misc/vec/vecPtr.h"
+
+
+ABC_NAMESPACE_IMPL_START
+
+void Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbose)
+{
+    Abc_Obj_t * pObj;
+    Abc_Obj_t * pFanout;
+    int i, j;
+    Vec_Int_t * vHyperEdgeEachWrite;
+    int Entry;
+    // check that the network is valid
+    assert( Abc_NtkIsStrash( pNtk ) && Abc_NtkIsComb( pNtk ));
+    
+    FILE * pFHMetis = fopen( pFileName, "wb" );
+    Vec_Ptr_t * vHyperEdges = Vec_PtrAlloc(1000);
+    if ( pFHMetis == NULL )
+    {
+        fprintf( stdout, "Io_WriteHMetis(): Cannot open the output file \"%s\".\n", pFileName );
+        ABC_FREE(pFHMetis);
+        return;
+    }
+    
+    //show pi/po/and number
+    if ( fVerbose )
+    {
+        Abc_Print( 1, "Writing hMetis file \"%s\" with %d nodes (%d pi, %d po, %d and nodes).\n", pFileName, Abc_NtkObjNum(pNtk), Abc_NtkPiNum(pNtk), Abc_NtkPoNum(pNtk), Abc_NtkNodeNum(pNtk) );
+    }
+    
+    Abc_NtkForEachObj( pNtk, pObj, i )
+    {
+        Vec_Int_t * vHyperEdgeEach = Vec_IntAlloc(20);
+        //push the node itself, which is a source node
+        Vec_IntPush(vHyperEdgeEach, Abc_ObjId(pObj));
+        //iterate through all the fanouts(sink) of the node
+        if( !Abc_ObjIsCo(pObj) )
+        {
+            Abc_ObjForEachFanout(pObj, pFanout, j)
+            {
+                Vec_IntPush(vHyperEdgeEach, Abc_ObjId(pFanout));
+            }
+        }
+        else{
+            if ( fSkipPo )
+            {
+                continue;
+            }
+            Vec_IntPush(vHyperEdgeEach, Abc_ObjId(Abc_ObjFanin0(pObj)));
+        }
+        Vec_PtrPush(vHyperEdges, vHyperEdgeEach); 
+    }
+    
+    //write the number of hyperedges and the number of vertices
+    fprintf(pFHMetis, "%d %d\n", Vec_PtrSize(vHyperEdges), Abc_NtkObjNum(pNtk));
+    //write the hyperedges
+    Vec_PtrForEachEntry(Vec_Int_t *, vHyperEdges, vHyperEdgeEachWrite, i)
+    {
+        Vec_IntForEachEntry(vHyperEdgeEachWrite, Entry, j)
+        {   
+            if (j == Vec_IntSize(vHyperEdgeEachWrite) - 1)
+            {
+                fprintf(pFHMetis, "%d", Entry);
+            }
+            else
+            {
+                fprintf(pFHMetis, "%d ", Entry);     
+            }           
+        }
+        fprintf(pFHMetis, "\n");
+    }
+    fprintf( pFHMetis, "\nThis file was written by ABC on %s\n", Extra_TimeStamp() );
+    fprintf( pFHMetis, "For information about hMetis format, refer to %s\n", "https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf" );
+    Vec_PtrFreeFree(vHyperEdges);
+}
+
+ABC_NAMESPACE_IMPL_END

--- a/src/base/io/ioWriteHMetis.c
+++ b/src/base/io/ioWriteHMetis.c
@@ -93,8 +93,9 @@ void Io_WriteHMetis( Abc_Ntk_t * pNtk, char * pFileName, int fSkipPo, int fVerbo
         }
         fprintf(pFHMetis, "\n");
     }
-    fprintf( pFHMetis, "\nThis file was written by ABC on %s\n", Extra_TimeStamp() );
-    fprintf( pFHMetis, "For information about hMetis format, refer to %s\n", "https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf" );
+    //comments should be started with "%" in hMetis format
+    fprintf( pFHMetis, "\n%%This file was written by ABC on %s\n", Extra_TimeStamp() );
+    fprintf( pFHMetis, "%%For information about hMetis format, refer to %s\n", "https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf" );
     Vec_PtrFreeFree(vHyperEdges);
 }
 

--- a/src/base/io/module.make
+++ b/src/base/io/module.make
@@ -26,6 +26,7 @@ SRC +=  src/base/io/io.c \
     src/base/io/ioWriteEqn.c \
     src/base/io/ioWriteEdgelist.c \
     src/base/io/ioWriteGml.c \
+    src/base/io/ioWriteHMetis.c \
     src/base/io/ioWriteList.c \
     src/base/io/ioWritePla.c \
     src/base/io/ioWriteVerilog.c \


### PR DESCRIPTION
A simple hypergraph format which has been used in [LSOracle hypergraph partition process](https://ieeexplore.ieee.org/document/8942145).

Constructing a hypergraph based on every edge(net) in aig context, which means every connected nodes are grouped together. Bottom-up, every node is a source, every fanout of the node is a sink, group all these together as one line. This part references [LSOracle](https://github.com/lnis-uofu/LSOracle/blob/febd1523e33bf5967a5556ec64c3d3057c54726e/core/algorithms/partitioning/hyperg.hpp#L53-L98).

The official manual of this format is [here](https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf), examples are in Figure 5. 
Only case no-weight(Figure 5.(a)) and case weight-on-hyperedge(Figure 5.(b)) are implemented. 

<details>

<summary>Example case on ctrl.aig from EPFL combinational benchmark</summary>

```shell
read_aiger ctrl.aig; strash; r2rs; r2rs; r2rs; logic; mfs2; strash; ps; write_hmetis -w show.graph
```
```
99 99 1
2 0 31
10 1 38 57 64 69 81 87 103 106 107
13 2 35 37 38 47 53 71 78 81 94 97 101 122
19 3 43 49 52 53 54 60 62 65 74 76 83 92 102 105 111 112 115 117
10 4 34 36 41 46 68 86 87 90 108
9 5 34 36 41 45 46 48 58 80
2 6 66
2 7 68
5 34 35 50 62 64
2 35 40
5 36 37 57 66 82
3 37 39 42
3 38 39 110
3 39 40 60
4 40 44 52 91
6 41 42 54 83 103 105
2 42 43
3 43 44 95
3 44 45 63
2 45 51
6 46 47 67 76 110 112
3 47 48 59
2 48 49
3 49 50 93
3 50 51 88
2 51 8
3 52 56 124
3 53 55 109
2 54 55
2 55 56
4 56 86 99 9
4 57 58 71 108
3 58 59 122
2 59 61
2 60 61
2 61 10
5 62 63 78 80 96
2 63 11
5 64 65 90 101 124
2 65 75
3 66 67 70
3 67 73 116
3 68 69 77
2 69 70
2 70 72
2 71 72
2 72 73
2 73 74
4 74 75 120 121
2 75 12
2 76 77
2 77 79
2 78 79
2 79 13
2 80 85
4 81 82 113 116
3 82 84 115
2 83 84
2 84 85
2 85 14
2 86 89
2 87 88
2 88 89
2 89 15
3 90 91 94
2 91 92
3 92 93 99
3 93 98 20
2 94 95
2 95 96
4 96 97 100 18
3 97 98 114
2 98 16
2 99 100
2 100 17
2 101 102
3 102 104 123
2 103 104
2 104 19
4 105 106 107 27
2 106 21
2 107 22
3 108 109 114
2 109 23
3 110 111 117
2 111 24
2 112 113
2 113 25
2 114 26
2 115 119
2 116 118
2 117 118
3 118 119 120
3 119 121 28
2 120 29
2 121 30
2 122 123
2 123 32
2 124 33

%This file was written by ABC on Thu Dec 26 21:05:00 2024
%For information about hMetis format, refer to https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf
```
</details>
