### PR TITLE
Fix(print_mffc): Missing condition when single output linked to CO

### DIFF
--- a/src/base/abci/abcPrint.c
+++ b/src/base/abci/abcPrint.c
@@ -1083,7 +1083,7 @@ void Abc_NtkPrintMffc( FILE * pFile, Abc_Ntk_t * pNtk )
     int i;
     extern void Abc_NodeMffcConeSuppPrint( Abc_Obj_t * pNode );
     Abc_NtkForEachNode( pNtk, pNode, i )
-        if ( Abc_ObjFanoutNum(pNode) > 1 )
+        if ( Abc_ObjFanoutNum(pNode) > 1 || (Abc_ObjFanoutNum(pNode) == 1 && Abc_ObjIsCo(Abc_ObjFanout0(pNode))))
             Abc_NodeMffcConeSuppPrint( pNode );
 }
 


### PR DESCRIPTION
# Bug
`print_mffc` can't print some simple examples.

# Minimum Reproducible Example (MRE)
Given aig
```
aag 5 3 0 1 2
2
4
6
10
8 2 4
10 8 6
```
which looks like:
<img width="318" alt="Screenshot 2025-01-17 at 18 20 48" src="https://github.com/user-attachments/assets/66fad3d9-7ea2-4a9e-a461-50f73c6ad7f7" />

run abc with following commands:
```
./abc -c "read_aiger noreconv.aig; ps; print_mffc"
ABC command line: "read_aiger noreconv.aig; ps; print_mffc".

noreconv                      : i/o =    3/    1  lat =    0  and =      2  lev =  2
```
No mffc statistic is printed.

# Analysis
The condition only considers dag node while missing the case when the node is a tree node but directly connected to PO. 

# Fix
After adding the corner case condition, the result will show the mffc in the circle.
<pre><code>
./abc -c "read_aiger noreconv.aig; ps; print_mffc"
ABC command line: "read_aiger noreconv.aig; ps; print_mffc".

noreconv                      : i/o =    3/    1  lat =    0  and =      2  lev =  2
<strong>Node =     n6 : Supp =   3  Cone =   2  ( n5 n6 )</strong>
</code></pre>