### PR TITLE
Feat(read_lib): Gz lib format support

### DIFF
--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -26,7 +26,6 @@
 #endif
 
 #include "misc/zlib/zlib.h"
-#include "misc/bzlib/bzlib.h"
 #include "sclLib.h"
 #include "misc/st/st.h"
 #include "map/mio/mio.h"

--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -25,6 +25,8 @@
 #include <fnmatch.h>
 #endif
 
+#include "misc/zlib/zlib.h"
+#include "misc/bzlib/bzlib.h"
 #include "sclLib.h"
 #include "misc/st/st.h"
 #include "map/mio/mio.h"
@@ -552,14 +554,59 @@ long Scl_LibertyFileSize( char * pFileName )
     fclose( pFile );
     return nFileSize;
 }
-char * Scl_LibertyFileContents( char * pFileName, long nContents )
+
+static char * Io_LibLoadFileGz( char * pFileName, long * pnFileSize )
 {
-    FILE * pFile = fopen( pFileName, "rb" );
-    char * pContents = ABC_ALLOC( char, nContents+1 );
-    long RetValue = 0;
-    RetValue = fread( pContents, nContents, 1, pFile );
-    fclose( pFile );
-    pContents[nContents] = 0;
+    const int READ_BLOCK_SIZE = 100000;
+    gzFile pFile;
+    char * pContents;
+    long amtRead, readBlock, nFileSize = READ_BLOCK_SIZE;
+    pFile = gzopen( pFileName, "rb" ); // if pFileName doesn't end in ".gz" then this acts as a passthrough to fopen
+    pContents = ABC_ALLOC( char, nFileSize );
+    readBlock = 0;
+    while ((amtRead = gzread(pFile, pContents + readBlock * READ_BLOCK_SIZE, READ_BLOCK_SIZE)) == READ_BLOCK_SIZE) {
+        //Abc_Print( 1,"%d: read %d bytes\n", readBlock, amtRead);
+        nFileSize += READ_BLOCK_SIZE;
+        pContents = ABC_REALLOC(char, pContents, nFileSize);
+        ++readBlock;
+    }
+    //Abc_Print( 1,"%d: read %d bytes\n", readBlock, amtRead);
+    assert( amtRead != -1 ); // indicates a zlib error
+    nFileSize -= (READ_BLOCK_SIZE - amtRead);
+    gzclose(pFile);
+    *pnFileSize = nFileSize;
+    return pContents;
+}
+
+char * Scl_LibertyFileContents( char * pFileName, long * nContents )
+{
+    char * pContents = NULL;
+    //if file ends in ".gz" then use gzopen
+    if ( !strncmp(pFileName+strlen(pFileName)-3,".gz", 3) )
+    {
+        FILE * pFile = fopen( pFileName, "rb" );
+        //char * pContents;
+        long RetValue = 0;
+        pContents = Io_LibLoadFileGz(  pFileName, nContents );
+        if(pContents == NULL) {
+            printf( "Scl_LibertyFileContents(): The input file is unavailable (absent or open).\n" );
+            return NULL;
+        }
+        else {
+            RetValue = 1;
+        }
+        fclose( pFile );
+    }
+    // original .lib file
+    else
+    {
+        FILE * pFile = fopen( pFileName, "rb" );
+        pContents = ABC_ALLOC( char, nContents+1 );
+        long RetValue = 0;
+        RetValue = fread( pContents, *nContents, 1, pFile );
+        fclose( pFile );
+        pContents[*nContents] = 0;
+    }
     return pContents;
 }
 void Scl_LibertyStringDump( char * pFileName, Vec_Str_t * vStr )
@@ -600,7 +647,7 @@ Scl_Tree_t * Scl_LibertyStart( char * pFileName )
     memset( p, 0, sizeof(Scl_Tree_t) );
     p->clkStart  = Abc_Clock();
     p->nContents = RetValue;
-    p->pContents = Scl_LibertyFileContents( pFileName, p->nContents );
+    p->pContents = Scl_LibertyFileContents( pFileName, &p->nContents );
     // other 
     p->pFileName = Abc_UtilStrsav( pFileName );
     p->nItermAlloc = 10 + Scl_LibertyCountItems( p->pContents, p->pContents+p->nContents );


### PR DESCRIPTION
# Why this
According to some issues in thread: https://github.com/YosysHQ/yosys/issues/4830 and https://github.com/YosysHQ/yosys/issues/4830#issuecomment-2573439711
`.gz` format is needed.

# How this is added
1. I notice that `read_aiger` and `read_blif` support `.gz` format, I use the **same function interface** here and rename it as `Io_LibLoadFileGz`.
2. As for `p->nContents`, I change it to a pointer, it will be updated by the gz interface, and it will remain the same in normal .lib format.

# Test & verify
- [x] I use the Nangate45 lib file, gzip it and read it in abc to check the content of `p->pContents`, it can be verified to be the same.
- [x] Same output.
```
./abc -c "read_lib NangateOpenCellLibrary_typical.lib"
ABC command line: "read_lib NangateOpenCellLibrary_typical.lib".

Library "NangateOpenCellLibrary" from "NangateOpenCellLibrary_typical.lib" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.05 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").

./abc -c "read_lib NangateOpenCellLibrary_typical.lib.gz"
ABC command line: "read_lib NangateOpenCellLibrary_typical.lib.gz".

Library "NangateOpenCellLibrary" from "NangateOpenCellLibrary_typical.lib.gz" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.06 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").
```
- [x] No leaks.
```
leaks --atExit -- ./abc -c "read_lib NangateOpenCellLibrary_typical.lib"   
abc(34863) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be included in process footprint - (null)
abc(34863) MallocStackLogging: recording malloc and VM allocation stacks using lite mode
ABC command line: "read_lib NangateOpenCellLibrary_typical.lib".

Library "NangateOpenCellLibrary" from "NangateOpenCellLibrary_typical.lib" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.05 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").
Process 34863 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         abc [34863]
Path:            /Users/USER/*/abc
Load Address:    0x1043d4000
Identifier:      abc
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [34862]

Date/Time:       2025-01-21 16:07:16.812 +0800
Launch Time:     2025-01-21 16:07:16.555 +0800
OS Version:      macOS 14.6 (23G80)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         8785K
Physical footprint (peak):  17.8M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 34863: 189 nodes malloced for 15 KB
Process 34863: 0 leaks for 0 total leaked bytes.
```
```
leaks --atExit -- ./abc -c "read_lib NangateOpenCellLibrary_typical.lib.gz"
abc(35732) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be included in process footprint - (null)
abc(35732) MallocStackLogging: recording malloc and VM allocation stacks using lite mode
ABC command line: "read_lib NangateOpenCellLibrary_typical.lib.gz".

Library "NangateOpenCellLibrary" from "NangateOpenCellLibrary_typical.lib.gz" has 90 cells (35 skipped: 21 seq; 6 tri-state; 8 no func; 10 dont_use).  Time =     0.07 sec
Warning: Detected 2 multi-output gates (for example, "FA_X1").
Process 35732 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         abc [35732]
Path:            /Users/USER/*/abc
Load Address:    0x102b38000
Identifier:      abc
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [35731]

Date/Time:       2025-01-21 16:07:27.548 +0800
Launch Time:     2025-01-21 16:07:27.313 +0800
OS Version:      macOS 14.6 (23G80)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         10.8M
Physical footprint (peak):  18.6M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 35732: 189 nodes malloced for 15 KB
Process 35732: 0 leaks for 0 total leaked bytes.
```