### PR TITLE
nf: Fix assert( pDp->F < FLT_MAX ); in nf

### DIFF
--- a/src/aig/gia/giaNf.c
+++ b/src/aig/gia/giaNf.c
@@ -1172,7 +1172,10 @@ void Nf_ManCutMatchOne( Nf_Man_t * p, int iObj, int * pCut, int * pCutSet )
             if ( ArrivalA + pC->iDelays[k] <= Required && Required != SCL_INFINITY )
             {
                 Delay = Abc_MaxInt( Delay, ArrivalA + pC->iDelays[k] );
-                AreaF += pBestF[iFanin]->M[fComplF][1].F;
+                if ( AreaF >= (float)1e32 || pBestF[iFanin]->M[fComplF][1].F >= (float)1e32 )
+                    AreaF = (float)1e32;
+                else
+                    AreaF += pBestF[iFanin]->M[fComplF][1].F;
             }
             else 
             {


### PR DESCRIPTION
This error was triggered by what appears to be a missing saturating float check in Nf_ManCutMatchOne. When opened in the debugger AreaF starts at FLT_MAX and in some cases can be added to itself which results in +Inf. I noticed the other if had a  saturating condidtion.

I took a flyer on it, and added it to the previous condition, and it resolved the error. I think this is a good fix.