### PR TITLE
Increase buffer size to DAU_MAX_STR (=2000).

### DIFF
--- a/src/opt/dau/dauGia.c
+++ b/src/opt/dau/dauGia.c
@@ -444,7 +444,7 @@ int Dsm_ManTruthToGia( void * p, word * pTruth, Vec_Int_t * vLeaves, Vec_Int_t *
     int fDelayBalance = 1;
     Gia_Man_t * pGia = (Gia_Man_t *)p;
     int nSizeNonDec;
-    char pDsd[1000];
+    char pDsd[DAU_MAX_STR];
     word pTruthCopy[DAU_MAX_WORD];
     Abc_TtCopy( pTruthCopy, pTruth, Abc_TtWordNum(Vec_IntSize(vLeaves)), 0 );
     m_Calls++;


### PR DESCRIPTION
DAU_MAX_STR (src/opt/dau/dau.h) has been increased from 1000 to 2000 in 716b8cc6b8079dba1638380f161b2ab03af7d401 (2014-03-10) such that, e.g., "strcpy( pRes, p->pOutput );" in "Dau_DsdDecompose" can write beyond the buffer size.

This bug occasionally corrupts the memory when using, e.g., "&if -K 12; &st".