### PR TITLE
Detect and avoid size overflow in "Vec_IntPush".

### DIFF
--- a/src/misc/vec/vecInt.h
+++ b/src/misc/vec/vecInt.h
@@ -26,6 +26,8 @@
 ///                          INCLUDES                                ///
 ////////////////////////////////////////////////////////////////////////
 
+#include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 
 ABC_NAMESPACE_HEADER_START
@@ -746,12 +748,17 @@ static inline void Vec_IntClear( Vec_Int_t * p )
 ***********************************************************************/
 static inline void Vec_IntPush( Vec_Int_t * p, int Entry )
 {
-    if ( p->nSize == p->nCap )
+    int nCap = p->nCap;
+    if ( p->nSize == nCap )
     {
+        assert( nCap < INT_MAX );
         if ( p->nCap < 16 )
             Vec_IntGrow( p, 16 );
         else
-            Vec_IntGrow( p, 2 * p->nCap );
+        {
+          nCap = 2*nCap > nCap ? 2*nCap : INT_MAX;
+          Vec_IntGrow( p, nCap );
+        }
     }
     p->pArray[p->nSize++] = Entry;
 }


### PR DESCRIPTION
The issue here is that "2*p->nCap" can underflow/overflow, but then afterward "p->nSize++" anyhow increments the size of the vector which then leads to index out-of-bounds accesses.

This bug occasionally corrupts the memory, e.g., when using "&if -K 12; &fx;" (because the number of cube pairs there can become really large).

Note 1: This issue appears more often in other ABC functions, too.
Note 2: This change doesn't really fix the issue for &fx, but the assertion will now fire and give a clear indication of what has happened instead of silently corrupting the memory.