### PR TITLE
Fix(write_hmetis): Remain the obj number when omitting POs explictly

### DIFF
--- a/src/base/io/ioWriteHMetis.c
+++ b/src/base/io/ioWriteHMetis.c
@@ -72,7 +72,7 @@ void Io_WriteHMetis( Abc_Ntk_t *pNtk, char *pFileName, int fSkipPo, int fWeightE
         Vec_PtrPush( vHyperEdges, vHyperEdgeEach );
     }
     
-    nHyperNodesNum = fSkipPo ? Abc_NtkObjNum( pNtk ) - Abc_NtkPoNum( pNtk ) : Abc_NtkObjNum( pNtk );
+    nHyperNodesNum = Abc_NtkObjNum( pNtk );
 
     // write the number of hyperedges and the number of vertices
     if ( fWeightEdges )

--- a/src/base/io/ioWriteHMetis.c
+++ b/src/base/io/ioWriteHMetis.c
@@ -103,7 +103,7 @@ void Io_WriteHMetis( Abc_Ntk_t *pNtk, char *pFileName, int fSkipPo, int fWeightE
         fprintf( pFHMetis, "\n" );
     }
     // comments should be started with "%" in hMetis format
-    fprintf( pFHMetis, "\n%%This file was written by ABC on %s\n", Extra_TimeStamp() );
+    fprintf( pFHMetis, "%%This file was written by ABC on %s\n", Extra_TimeStamp() );
     fprintf( pFHMetis, "%%For information about hMetis format, refer to %s\n", "https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf" );
     Vec_PtrFreeFree( vHyperEdges );
     fclose( pFHMetis );


### PR DESCRIPTION
## What issue
The result of `write_hmetis` won't work on [Mt-kahypar](https://github.com/kahypar/mt-kahypar).

## Why this
This fix is actually from a test when partitioning on [Mt-kahypar](https://github.com/kahypar/mt-kahypar), I used to set a default `-s` to omit the POs explicitly (since the single connection between the PO and node $n$ shows up twice when collecting), but when iterating fanouts of AND object type, ID of POs still shows up in AND node's fanout data(on Hyperedges), so the nHyperNodesNum should still be `Abc_NtkObjNum( pNtk )`.

## How to fix
Set `nHyperNodesNum` to  `Abc_NtkObjNum( pNtk )` even when omitting to a compact form.

## Verified result and detailed log
Running by 
```
./MtKaHyPar -h i10.hpg --preset-type=default -t 3 -k 4 -e 0.03 -o km1
```
### When skip by default
```
******************************************************************************** 
*                             Partitioning Result                              * 
******************************************************************************** 
Objectives: 
  km1                  = 118 (primary objective function) 
  cut                  = 109  
  soed                 = 227  
  Imbalance            = 0.021519  
  Partitioning Time    = 0.531044 s  

Partition sizes and weights:  
|block 0| = 766  w( 0 ) = 766  max( 0 ) = 813
|block 1| = 807  w( 1 ) = 807  max( 1 ) = 813
|block 2| = 807  w( 2 ) = 807  max( 2 ) = 813
|block 3| = 777  w( 3 ) = 777  max( 3 ) = 813

Timings: 
 + I/O Hypergraph                             = 0.0137455 s
 + Memory Pool Allocation                     = 0.000673625 s
 + Preprocessing                              = 0.0367002 s
 + Coarsening                                 = 0.0227134 s
 + Initial Partitioning                       = 0.42489 s
 + Refinement                                 = 0.038314 s
 + Postprocessing                             = 5e-06 s
```

### When no skip(redundant)

```
******************************************************************************** 
*                             Partitioning Result                              * 
******************************************************************************** 
Objectives: 
  km1                  = 127 (primary objective function) 
  cut                  = 119  
  soed                 = 246  
  Imbalance            = 0.0253165  
  Partitioning Time    = 0.486559 s  

Partition sizes and weights:  
|block 0| = 749  w( 0 ) = 749  max( 0 ) = 813
|block 1| = 810  w( 1 ) = 810  max( 1 ) = 813
|block 2| = 809  w( 2 ) = 809  max( 2 ) = 813
|block 3| = 789  w( 3 ) = 789  max( 3 ) = 813

Timings: 
 + I/O Hypergraph                             = 0.0143289 s
 + Memory Pool Allocation                     = 0.000712625 s
 + Preprocessing                              = 0.0367743 s
 + Coarsening                                 = 0.02276 s
 + Initial Partitioning                       = 0.388305 s
 + Refinement                                 = 0.0302472 s
 + Postprocessing                             = 5.5e-06 s
```
Full log of Skip and no Skip:
[trace_no_skip.log](https://github.com/user-attachments/files/18985041/trace_no_skip.log)
[trace_skip_default.log](https://github.com/user-attachments/files/18985042/trace_skip_default.log)

## Notice
hmetis format does support comment at the end start with `%`, I find the result generated can't be parsed by Mt-kahypar unless you delete the comments:
```
%This file was written by ABC on Wed Feb 26 21:34:13 2025
%For information about hMetis format, refer to https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf
```
 I added in the end, I also opened an issue [here](https://github.com/kahypar/mt-kahypar/issues/204) in Mt-kahypar, if any of you are interested.
