### PR TITLE
Fix(Pointer): Fix the wrong value passed to size

### DIFF
--- a/src/map/scl/sclLiberty.c
+++ b/src/map/scl/sclLiberty.c
@@ -600,7 +600,7 @@ char * Scl_LibertyFileContents( char * pFileName, long * nContents )
     else
     {
         FILE * pFile = fopen( pFileName, "rb" );
-        pContents = ABC_ALLOC( char, nContents+1 );
+        pContents = ABC_ALLOC( char, *nContents+1 );
         long RetValue = 0;
         RetValue = fread( pContents, *nContents, 1, pFile );
         fclose( pFile );


### PR DESCRIPTION
## What
I used to change `nContent` to pointer in PR https://github.com/berkeley-abc/abc/pull/362 , but missing this line when carelessly copy-paste the original implementation. The size of the malloced space is wrongly passed a pointer. When I read a library `sky130_fd_sc_hd__tt_025C_1v80.lib`, the crash shows, I believe this might also cause the issue #372 .

## Why didn't notice
I believe that the address of `nContent` is reinterpreted and casted to a `size_t` in 
```
#define ABC_ALLOC(type, num)     ((type *) malloc(sizeof(type) * (size_t)(num)))
```
and sometimes this address is a large number and even memory check tool like leaks didn't notice.

## How
`nContents` to `*nContents`

## Check
Before
```
(lldb) r -c "read_lib ./sky130_fd_sc_hd__tt_025C_1v80.lib"
There is a running process, kill it and restart?: [Y/n] Y
Process 63230 exited with status = 9 (0x00000009) killed
Process 70395 launched: '/Users/jingrenwang/Github/ABC/abcOri/abc/abc' (arm64)
ABC command line: "read_lib ./sky130_fd_sc_hd__tt_025C_1v80.lib".

Process 70395 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xc3f2a5)
    frame #0: 0x000000010038bf30 abc`Scl_LibertyFileContents(pFileName="./sky130_fd_sc_hd__tt_025C_1v80.lib", nContents=0x0000600003b180b0) at sclLiberty.c:607:31 [opt]
   604          long RetValue = 0;
   605          RetValue = fread( pContents, *nContents, 1, pFile );
   606          fclose( pFile );
-> 607          pContents[*nContents] = 0;
   608      }
   609      return pContents;
   610  }
Target 0: (abc) stopped.
```
After
```
(lldb) r -c "read_lib ./sky130_fd_sc_hd__tt_025C_1v80.lib"
Process 73765 launched: '/Users/jingrenwang/Github/ABC/abcOri/abc/abc' (arm64)
ABC command line: "read_lib ./sky130_fd_sc_hd__tt_025C_1v80.lib".

Library "sky130_fd_sc_hd__tt_025C_1v80" from "./sky130_fd_sc_hd__tt_025C_1v80.lib" has 334 cells (94 skipped: 63 seq; 13 tri-state; 18 no func; 0 dont_use).  Time =     0.08 sec
Warning: Detected 9 multi-output gates (for example, "sky130_fd_sc_hd__fa_1").
Process 73765 exited with status = 0 (0x00000000) 
```