### PR TITLE
Fix the NULL Pointer Dereference vulnerability in `Abc_NtkCecFraigPart`.

### DIFF
--- a/src/base/abci/abcVerify.c
+++ b/src/base/abci/abcVerify.c
@@ -324,6 +324,12 @@ void Abc_NtkCecFraigPart( Abc_Ntk_t * pNtk1, Abc_Ntk_t * pNtk2, int nSeconds, in
         }
         else if ( RetValue == 0 )
         {
+            if(!pMiterPart)
+            {
+                printf("ERROR: Failed to create cone for output %d.\n", i);
+                Status = -1; 
+                break; 
+            }
             int * pSimInfo = Abc_NtkVerifySimulatePattern( pMiterPart, pMiterPart->pModel );
             if ( pSimInfo[0] != 1 )
                 printf( "ERROR in Abc_NtkMiterProve(): Generated counter-example is invalid.\n" );


### PR DESCRIPTION
How the NULL Pointer Dereference happens:
1. `pMiterPart` is set to NULL by `pMiterPart = NULL;`
2. When the following conditions are met:  `RetValue == 0`
3. Dereference of NULL variable `pMiterPart->pModel` in 
`Abc_NtkVerifySimulatePattern( pMiterPart, pMiterPart->pModel );`
```
void Abc_NtkCecFraigPart( Abc_Ntk_t * pNtk1, Abc_Ntk_t * pNtk2, int nSeconds, 
                                int nPartSize, int fVerbose )
{
    Prove_Params_t Params, * pParams = &Params;
    Abc_Ntk_t * pMiter, * pMiterPart;
    Abc_Obj_t * pObj;
    int i, RetValue, Status, nOutputs;
    ......

=>  Abc_NtkForEachPo( pMiter, pObj, i )
    {
=>      if ( Abc_ObjFanin0(pObj) == Abc_AigConst1(pMiter) )
        {
            if ( Abc_ObjFaninC0(pObj) ) // complemented -> const 0
                RetValue = 1;
            else
=>              RetValue = 0;
=>          pMiterPart = NULL;
        }
        else
        {
           ......
        }

        if ( RetValue == -1 )
        {
            ......
        }
        else if ( RetValue == 0 )
        {
=>          int * pSimInfo = Abc_NtkVerifySimulatePattern( pMiterPart, pMiterPart->pModel );
            ......
        }
        ......
    }
    ......
 }

```