### PR TITLE
Fix the null reference vulnerability

### DIFF
--- a/src/base/abci/abcOrchestration.c
+++ b/src/base/abci/abcOrchestration.c
@@ -4444,6 +4444,8 @@ Rwr_ManAddTimeCuts( pManRwr, Abc_Clock() - clk );
         // skip persistant nodes
         if ( Abc_NodeIsPersistant(pNode) )
         {
+            if (!(pGain_res && pGain_ref && pGain_rwr))
+                return 0;
             fprintf(fpt, "%d, %s, %d\n", pNode->Id, "None" , -99);
             Vec_IntPush((*pGain_res), -99);
             Vec_IntPush((*pGain_ref), -99);
@@ -4453,6 +4455,8 @@ Rwr_ManAddTimeCuts( pManRwr, Abc_Clock() - clk );
         // skip the nodes with many fanouts
         if ( Abc_ObjFanoutNum(pNode) > 1000 )
         {
+            if (!(pGain_res && pGain_ref && pGain_rwr))
+                return 0;
             fprintf(fpt, "%d, %s, %d\n", pNode->Id,"None", -99);
             Vec_IntPush((*pGain_res), -99);
             Vec_IntPush((*pGain_ref), -99);


### PR DESCRIPTION
NULL Pointer Dereference vulnerability in `Abc_NtkOchestration3`.
The NULL Dereference vulnerability happens in  `int Abc_NtkOchestration3()`, `base/abci/abcOrchestration.c`
How the NULL Pointer Dereference happens:
1. When `pGain_res`, `pGain_ref` or `pGain_rwr` is null. 
2. Dereference of NULL variable `*pGain_res`, `*pGain_ref` or `*pGain_rwr` in 
`Vec_IntPush((*pGain_res), -99);`
`Vec_IntPush((*pGain_ref), -99);`
`Vec_IntPush((*pGain_rwr), -99);`
```
int Abc_NtkOchestration3( Abc_Ntk_t * pNtk, Vec_Int_t **pGain_rwr, 
                            Vec_Int_t **pGain_res, Vec_Int_t **pGain_ref, 
                            Vec_Int_t **pOps_num, int fUseZeros, 
                            int fUseZeros_rwr, int fUseZeros_ref, 
                            int fPlaceEnable, int nCutMax, int nStepsMax, 
                            int nLevelsOdc, int fUpdateLevel, int fVerbose, 
                            int fVeryVerbose, int nNodeSizeMax, int nConeSizeMax, int fUseDcs )
{
    ProgressBar * pProgress;
    // For resub
    Abc_ManRes_t * pManRes;
    Abc_ManCut_t * pManCutRes;
    Odc_Man_t * pManOdc = NULL;
    Dec_Graph_t * pFFormRes;
    Dec_Graph_t * pFFormRef_zeros;
    Vec_Ptr_t * vLeaves;
    ......

    nNodes = Abc_NtkObjNumMax(pNtk);
    //printf("nNodes: %d\n", nNodes);
=>  if (pGain_res) *pGain_res = Vec_IntAlloc(1);
=>  if (pGain_ref) *pGain_ref = Vec_IntAlloc(1);
=>  if (pGain_rwr) *pGain_rwr = Vec_IntAlloc(1);
    Abc_NtkForEachNode( pNtk, pNode, i )   
    {
        if (pOps_num) *pOps_num = Vec_IntAlloc(1);
            Extra_ProgressBarUpdate( pProgress, i, NULL );
        if ( Abc_NodeIsPersistant(pNode) )
        {
            fprintf(fpt, "%d, %s, %d\n", pNode->Id, "None" , -99);
=>          Vec_IntPush((*pGain_res), -99);
=>          Vec_IntPush((*pGain_ref), -99);
=>          Vec_IntPush((*pGain_rwr), -99);
            continue;
        } 
        // skip the nodes with many fanouts
        if ( Abc_ObjFanoutNum(pNode) > 1000 )
        {
            fprintf(fpt, "%d, %s, %d\n", pNode->Id,"None", -99);
=>          Vec_IntPush((*pGain_res), -99);
=>          Vec_IntPush((*pGain_ref), -99);
=>          Vec_IntPush((*pGain_rwr), -99);
            continue;
        }
        ......
    }
    ......
 }

```