### PR TITLE
Refactor(cmake): Generate compilation database

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.5.0)
 include(CMakeParseArguments)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+# Generate compilation database compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Default c++ standard used unless otherwise specified in target_compile_features.
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "the C++ standard to use for this project")


### PR DESCRIPTION
# Why
This change is not feature related, just for those who use clangd etc like me and sometimes get a missing definition error related to header file/variables/functions in editor.

# What
If specify `CMAKE_EXPORT_COMPILE_COMMANDS`, a [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) will be generated and when [point clangd to this file](https://clangd.llvm.org/design/compile-commands#compilation-databases) it will solve definition missing error for good in editor.

# How
Just turn on [it](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) in CMake. It will automatically be generated in `/build` folder