### PR TITLE
Support primitive gates with names in Verilog netlist

### DIFF
--- a/src/base/ver/verCore.c
+++ b/src/base/ver/verCore.c
@@ -1339,12 +1339,26 @@ int Ver_ParseGateStandard( Ver_Man_t * pMan, Abc_Ntk_t * pNtk, Ver_GateType_t Ga
         return 0;
     Ver_StreamMove( p );
 
-    // this is gate name - throw it away
+    // assume there is a gate name if the current char is not '(', e.g. xor g1 (z, a, b);
     if ( Ver_StreamPopChar(p) != '(' )
     {
-        sprintf( pMan->sError, "Cannot parse a standard gate (expected opening parenthesis)." );
-        Ver_ParsePrintErrorMessage( pMan );
-        return 0;
+            // this is gate name - throw it away
+        pWord = Ver_ParseGetName( pMan );
+        if (pWord == NULL)
+        {
+            sprintf( pMan->sError, "Cannot parse a standard gate (expected a name before an opening parenthesis)." );
+            Ver_ParsePrintErrorMessage( pMan );
+            return 0;
+        }
+        else
+        {
+            if ( Ver_StreamPopChar(p) != '(' )
+            {
+                sprintf( pMan->sError, "Cannot parse a standard gate (expected opening parenthesis)." );
+                Ver_ParsePrintErrorMessage( pMan );
+                return 0;
+            }
+        }
     }
     Ver_ParseSkipComments( pMan );
 


### PR DESCRIPTION
Hi, I have modified the Verilog parser to allow reading primitive gates with names. The following Verilog code could not be parsed because the gates have names:
```Verilog
module top (a, b, c);
input a;
input b;
output c;

wire n1;

xor t1(n1, a, b);
or t2 (c, a, b, n1);
endmodule
```

This pull request allows it to be parsed successfully.