### PR TITLE
Prevent merged scl filename size from growing unbounded.

### DIFF
--- a/src/map/scl/sclLibScl.c
+++ b/src/map/scl/sclLibScl.c
@@ -875,7 +875,7 @@ SC_Lib * Abc_SclMergeLibraries( SC_Lib * pLib1, SC_Lib * pLib2, int fUsePrefix )
     SC_Lib * p = Abc_SclReadFromStr( vOut );
     p->pFileName = Abc_UtilStrsav( pLib1->pFileName );
     p->pName = ABC_ALLOC( char, strlen(pLib1->pName) + strlen(pLib2->pName) + 10 );
-    sprintf( p->pName, "%s__and__%s", pLib1->pName, pLib2->pName );
+    sprintf( p->pName, "merged_lib_size_%d", p->vCells.nSize );
     Vec_StrFree( vOut );
     printf( "Updated library \"%s\" with additional %d cells from library \"%s\".\n", pLib1->pName, n_valid_cells2, pLib2->pName );
     return p;


### PR DESCRIPTION
In the current implementation, loading an additional liberty file with `read_lib -m` is handled internally by abc by writing out a new file with the previous file name suffixed with the new liberty file name. When loading many liberty files (which can happen in flows with many individual macro files, corners, Vts, etc.), this can cause a crash by exceeding the maximum allowed file name. The maximum number of files loaded is limited by this behavior.

This change modifies this behavior to use a total cell count of the merged library instead, so the file name does not grow unbounded.

