### PR TITLE
Fix(&if): Core dump on -IF_INFINITY

### DIFF
--- a/src/map/if/ifCount.h
+++ b/src/map/if/ifCount.h
@@ -25,6 +25,7 @@
 ///                          INCLUDES                                ///
 ////////////////////////////////////////////////////////////////////////
 
+#include "map/if/if.h"
 ABC_NAMESPACE_HEADER_START
 
 ////////////////////////////////////////////////////////////////////////
@@ -214,7 +215,10 @@ static inline int If_LogCounterPinDelays( int * pTimes, int * pnTimes, word * pP
                 ABC_SWAP( word, pPinDels[k], pPinDels[k-1] ); 
                 continue; 
             }
-            pTimes[k-1] += 1 + fXor;
+            if(pTimes[k-1] != -IF_INFINITY)
+            {
+                pTimes[k-1] += 1 + fXor;
+            }
             pPinDels[k-1] = If_CutPinDelayMax( pPinDels[k], pPinDels[k-1], nSuppAll, 1 + fXor );
             for ( nTimes--, i = k; i < nTimes; i++ )
             {


### PR DESCRIPTION
Temporary fix the core dump of issue #428 

The original issue asserts on `-99999999 == -100000000`.
The AND gate's `pTimes`(cut leaves delay) could contains value such as `-IF_INFINITY`(-100000000), and the tie breaker on equal condition is excluded on `-IF_INFINITY` here. 