### PR TITLE
Add Windows fixes so abc compiles natively with GCC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ $(call abc_info,$(MSG_PREFIX)Using AR=$(AR))
 $(call abc_info,$(MSG_PREFIX)Using LD=$(LD))
 
 PROG := abc
+
 OS := $(shell uname -s)
+ifneq ($(filter MINGW%,$(OS)),)
+OS := MINGW
+endif
 
 MODULES := \
 	$(wildcard src/ext*) \
@@ -151,8 +155,13 @@ ifneq ($(OS), $(filter $(OS), FreeBSD OpenBSD NetBSD))
   LIBS += -ldl
 endif
 
-ifneq ($(OS), $(filter $(OS), FreeBSD OpenBSD NetBSD Darwin))
+ifneq ($(OS), $(filter $(OS), FreeBSD OpenBSD NetBSD Darwin MINGW))
    LIBS += -lrt
+endif
+
+# For PathMatchSpecA.
+ifeq ($(OS), MINGW)
+   LIBS = -lshlwapi
 endif
 
 ifdef ABC_USE_LIBSTDCXX
@@ -164,7 +173,7 @@ $(call abc_info,$(MSG_PREFIX)Using CFLAGS=$(CFLAGS))
 CXXFLAGS += $(CFLAGS) -std=c++17 -fno-exceptions
 
 SRC  :=
-GARBAGE := core core.* *.stackdump ./tags $(PROG) arch_flags
+GARBAGE := core core.* *.stackdump ./tags $(PROG) arch_flags $(PROG).in
 
 .PHONY: all default tags clean docs cmake_info
 
@@ -231,9 +240,17 @@ clean:
 tags:
 	etags `find . -type f -regex '.*\.\(c\|h\)'`
 
+ifeq ($(OS), MINGW)
+$(PROG): $(OBJ)
+	@echo "$(MSG_PREFIX)\`\` Constructing Response File:" $(notdir @$@.in)
+	$(file >$@.in,$^ $(LDFLAGS) $(LIBS))
+	@echo "$(MSG_PREFIX)\`\` Building binary:" $(notdir $@)
+	$(VERBOSE)$(LD) -o $@ @$@.in
+else
 $(PROG): $(OBJ)
 	@echo "$(MSG_PREFIX)\`\` Building binary:" $(notdir $@)
 	$(VERBOSE)$(LD) -o $@ $^ $(LDFLAGS) $(LIBS)
+endif
 
 lib$(PROG).a: $(LIBOBJ)
 	@echo "$(MSG_PREFIX)\`\` Linking:" $(notdir $@)


### PR DESCRIPTION
This PR fixes some Windows compilation issues I found when compiling with GCC on Windows (MinGW64/MSYS2 specifically in my case):

* ~~Turns some `WIN32` checks into more-accurate MSVC-specific checks using `_MSC_VER` variable. These should not affect compilation with MSVC.~~ Fixed upstream in the meantime.
* Remove `-lrt` from the linked libraries (doesn't really exist for Windows, AFAIR), and _add_ the `-lshlwapi` library because `abc` uses [`PathMatchSpecA`](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathmatchspeca) somehow.
* ABC's link command-line has unfortunately gotten large enough that it exceeds the 32768-or-so character limit on the command-line. The workaround is [Response](https://gcc.gnu.org/wiki/Response_Files) [Files](https://learn.microsoft.com/en-us/windows/win32/midl/response-files)- i.e. supply the command-line arguments via a dynamically-generated file. I use GNU Make's [`file`](https://www.gnu.org/software/make/manual/html_node/File-Function.html) function for this; the docs even state that response files are an intended usage :D.
* At least in the case of MinGW, `uname -s` isn't necessarily static (it appends a version string, which can vary between systems). I bring in [code from `yosys`](https://github.com/YosysHQ/yosys/blob/8c71226d0050b3ff71e9bc44297480811a21bb56/Makefile#L66-L68) to make the `OS` variable remain the same between systems.

I mainly follow the [`yosys` branch](https://github.com/YosysHQ/abc) of ABC, so I was able to compile `abc` without issue until a recent merge. By looking at the yosys branch and main side-by-side (`git log  --all --decorate --oneline --graph`), it seems all the commits that required me to make these changes were between 68c576cc5 and now (9c41da69d).