### PR TITLE
Refactor bit counting functions to use Abc_WordCountOnes

### DIFF
--- a/src/aig/aig/aig.h
+++ b/src/aig/aig/aig.h
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "misc/util/abc_global.h"
 #include "misc/vec/vec.h"
 #include "misc/util/utilCex.h"
 
@@ -226,14 +227,7 @@ static inline Aig_Cut_t *  Aig_CutNext( Aig_Cut_t * pCut )              { return
 ////////////////////////////////////////////////////////////////////////
 
 static inline unsigned     Aig_ObjCutSign( unsigned ObjId )       { return (1U << (ObjId & 31));                            }
-static inline int          Aig_WordCountOnes( unsigned uWord )
-{
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
-}
+static inline int          Aig_WordCountOnes( unsigned uWord )    { return Abc_WordCountOnes( uWord );                      }
 static inline int          Aig_WordFindFirstBit( unsigned uWord )
 {
     int i;

--- a/src/aig/aig/aigPack.c
+++ b/src/aig/aig/aigPack.c
@@ -43,7 +43,7 @@ struct Aig_ManPack_t_
     int                nPatRepeat;  // number of repeated patterns
 };
 
-static inline int Aig_Word6CountOnes( word t )  { return Aig_WordCountOnes( (unsigned)(t >> 32) ) + Aig_WordCountOnes( (unsigned)(t & 0xFFFFFFFF) ); }
+static inline int Aig_Word6CountOnes( word t )  { return Abc_Word6CountOnes( t ); }
 static inline int Aig_Word6HasOneBit( word t )  { return (t & (t-1)) == 0; }
 
 

--- a/src/aig/gia/gia.h
+++ b/src/aig/gia/gia.h
@@ -394,14 +394,7 @@ struct Jf_Par_t_
 static inline unsigned     Gia_ObjCutSign( unsigned ObjId )       { return (1 << (ObjId & 31));                                 }
 static inline int          Gia_WordHasOneBit( unsigned uWord )    { return (uWord & (uWord-1)) == 0;                            }
 static inline int          Gia_WordHasOnePair( unsigned uWord )   { return Gia_WordHasOneBit(uWord & (uWord>>1) & 0x55555555);  }
-static inline int          Gia_WordCountOnes( unsigned uWord )
-{
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
-}
+static inline int          Gia_WordCountOnes( unsigned uWord )    { return Abc_WordCountOnes( uWord );                          }
 static inline int Gia_WordFindFirstBit( unsigned uWord )
 {
     int i;

--- a/src/aig/ivy/ivyDsd.c
+++ b/src/aig/ivy/ivyDsd.c
@@ -73,11 +73,7 @@ static unsigned s_Masks[6][2] = {
 
 static inline int        Ivy_TruthWordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 
 static inline int        Ivy_TruthCofactorIsConst( unsigned uTruth, int Var, int Cof, int Const )

--- a/src/bool/kit/kit.h
+++ b/src/bool/kit/kit.h
@@ -245,11 +245,7 @@ static inline int Kit_WordHasOneBit( unsigned uWord )
 }
 static inline int Kit_WordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 static inline int Kit_TruthCountOnes( unsigned * pIn, int nVars )
 {

--- a/src/map/if/ifMap.c
+++ b/src/map/if/ifMap.c
@@ -95,11 +95,7 @@ int If_ManCutAigDelay( If_Man_t * p, If_Obj_t * pObj, If_Cut_t * pCut )
 ***********************************************************************/
 static inline int If_WordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 
 /**Function*************************************************************

--- a/src/map/if/ifSelect.c
+++ b/src/map/if/ifSelect.c
@@ -170,11 +170,7 @@ int If_ManNodeShapeMap( If_Man_t * pIfMan, If_Obj_t * pIfObj, Vec_Int_t * vShape
 ***********************************************************************/
 static inline int  If_WordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 int If_ManNodeShapeMap2_rec( If_Man_t * pIfMan, If_Obj_t * pIfObj, Vec_Ptr_t * vVisited, Vec_Int_t * vShape )
 {

--- a/src/misc/extra/extra.h
+++ b/src/misc/extra/extra.h
@@ -257,11 +257,7 @@ static inline int   Extra_TruthHasBit( unsigned * p, int Bit )   { return (p[Bit
 
 static inline int Extra_WordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 static inline int Extra_TruthCountOnes( unsigned * pIn, int nVars )
 {

--- a/src/misc/util/abc_global.h
+++ b/src/misc/util/abc_global.h
@@ -369,6 +369,34 @@ static inline abctime Abc_ThreadClock()
 #endif
 }
 
+static inline int Abc_WordCountOnes( unsigned uWord )
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_popcount( uWord );
+#elif defined(_MSC_VER)
+    #include <intrin.h>
+    return __popcnt( uWord );
+#else
+    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
+    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
+    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
+    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
+    return  (uWord & 0x0000FFFF) + (uWord>>16);
+#endif
+}
+
+static inline int Abc_Word6CountOnes( word t )
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_popcountl( t );
+#elif defined(_MSC_VER)
+    #include <intrin.h>
+    return __popcnt64( t );
+#else
+    return Abc_WordCountOnes( (unsigned)(t >> 32) ) + Abc_WordCountOnes( (unsigned)(t & 0xFFFFFFFF) );
+#endif
+}
+
 // misc printing procedures
 enum Abc_VerbLevel
 {

--- a/src/misc/vec/vecBit.h
+++ b/src/misc/vec/vecBit.h
@@ -571,11 +571,7 @@ static inline int Vec_BitPop( Vec_Bit_t * p )
 ***********************************************************************/
 static inline int Vec_BitCountWord( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 
 /**Function*************************************************************

--- a/src/opt/dar/darCut.c
+++ b/src/opt/dar/darCut.c
@@ -85,11 +85,7 @@ void Dar_ObjCutPrint( Aig_Man_t * p, Aig_Obj_t * pObj )
 ***********************************************************************/
 static inline int Dar_WordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 
 /**Function*************************************************************

--- a/src/opt/dau/dauTree.c
+++ b/src/opt/dau/dauTree.c
@@ -138,11 +138,7 @@ static inline Dss_Obj_t *  Dss_ObjChild( Vec_Ptr_t * p, Dss_Obj_t * pObj, int i 
 
 static inline int Dss_WordCountOnes( unsigned uWord )
 {
-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
-    return  (uWord & 0x0000FFFF) + (uWord>>16);
+    return Abc_WordCountOnes( uWord );
 }
 
 static inline int Dss_Lit2Lit( int * pMapLit, int Lit )   { return Abc_Var2Lit( Abc_Lit2Var(pMapLit[Abc_Lit2Var(Lit)]), Abc_LitIsCompl(Lit) ^ Abc_LitIsCompl(pMapLit[Abc_Lit2Var(Lit)]) );   }

--- a/src/opt/fxch/Fxch.h
+++ b/src/opt/fxch/Fxch.h
@@ -146,11 +146,7 @@ extern int        Abc_NtkFxCheck( Abc_Ntk_t* pNtk );
 
 static inline int Fxch_CountOnes( unsigned num )
 {
-    num = ( num & 0x55555555 ) + ( ( num >> 1) & 0x55555555 );
-    num = ( num & 0x33333333 ) + ( ( num >> 2) & 0x33333333 );
-    num = ( num & 0x0F0F0F0F ) + ( ( num >> 4) & 0x0F0F0F0F );
-    num = ( num & 0x00FF00FF ) + ( ( num >> 8) & 0x00FF00FF );
-    return  ( num & 0x0000FFFF ) + ( num >> 16 );
+    return Abc_WordCountOnes( num );
 }
 
 /*===== Fxch.c =======================================================*/


### PR DESCRIPTION
This pr centralizes and unifies various bit counting implementations across the codebase by replacing them with a single call to `Abc_WordCountOnes`.

This function now utilizes compiler-specific intrinsics: `__builtin_popcount` for GCC/Clang and the equivalent intrinsic for MSVC. It also remains the old code as a fallback.

This pr may improve the code reuse and optimize performance. 