### PR TITLE
The target's INTERFACE_INCLUDE_DIRECTORIES should not contain a path …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(ABC_USE_NAMESPACE)
 endif()
 
 function(abc_properties target visibility)
-    target_include_directories(${target} ${visibility} ${CMAKE_CURRENT_SOURCE_DIR}/src )
+    target_include_directories(${target} ${visibility} $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> $<INSTALL_INTERFACE:include/abc> )
     target_compile_options_filtered(${target} ${visibility} ${ABC_CFLAGS} ${ABC_CXXFLAGS} -Wno-unused-but-set-variable )
     target_link_libraries(${target} ${visibility} ${ABC_LIBS})
 endfunction()


### PR DESCRIPTION
…that points into the source tree.

This solves an issue with relatively newer CMake versions that results in this error:
```
CMake Error in [...]/CMakeLists.txt:
  Target "libabc-pic" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "[...]/src"

  which is prefixed in the build directory.
```