### PR TITLE
Reduce the amount of text printed when building `abc`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,19 @@ MSG_PREFIX ?=
 ABCSRC ?= .
 VPATH = $(ABCSRC)
 
-$(info $(MSG_PREFIX)Using CC=$(CC))
-$(info $(MSG_PREFIX)Using CXX=$(CXX))
-$(info $(MSG_PREFIX)Using AR=$(AR))
-$(info $(MSG_PREFIX)Using LD=$(LD))
+# whether to print build options, tools, and echo commands while building
+ifdef ABC_MAKE_VERBOSE
+  VERBOSE=
+  abc_info = $(info $(1))
+else
+  VERBOSE=@
+  abc_info =
+endif
+
+$(call abc_info,$(MSG_PREFIX)Using CC=$(CC))
+$(call abc_info,$(MSG_PREFIX)Using CXX=$(CXX))
+$(call abc_info,$(MSG_PREFIX)Using AR=$(AR))
+$(call abc_info,$(MSG_PREFIX)Using LD=$(LD))
 
 PROG := abc
 OS := $(shell uname -s)
@@ -66,14 +75,14 @@ endif
 ifdef ABC_USE_NAMESPACE
   CFLAGS += -DABC_NAMESPACE=$(ABC_USE_NAMESPACE) -fpermissive -x c++
   CC := $(CXX)
-  $(info $(MSG_PREFIX)Compiling in namespace $(ABC_USE_NAMESPACE))
+  $(call abc_info,$(MSG_PREFIX)Compiling in namespace $(ABC_USE_NAMESPACE))
 endif
 
 # compile CUDD with ABC
 ifndef ABC_USE_NO_CUDD
   CFLAGS += -DABC_USE_CUDD=1
   MODULES += src/bdd/cudd src/bdd/extrab src/bdd/dsd src/bdd/epd src/bdd/mtr src/bdd/reo src/bdd/cas src/bdd/bbr src/bdd/llb
-  $(info $(MSG_PREFIX)Compiling with CUDD)
+  $(call abc_info,$(MSG_PREFIX)Compiling with CUDD)
 endif
 
 ABC_READLINE_INCLUDES ?=
@@ -87,28 +96,21 @@ ifndef ABC_USE_NO_READLINE
     CFLAGS += -I/usr/local/include
     LDFLAGS += -L/usr/local/lib
   endif
-  $(info $(MSG_PREFIX)Using libreadline)
+  $(call abc_info,$(MSG_PREFIX)Using libreadline)
 endif
 
 # whether to compile with thread support
 ifndef ABC_USE_NO_PTHREADS
   CFLAGS += -DABC_USE_PTHREADS
   LIBS += -lpthread
-  $(info $(MSG_PREFIX)Using pthreads)
+  $(call abc_info,$(MSG_PREFIX)Using pthreads)
 endif
 
 # whether to compile into position independent code
 ifdef ABC_USE_PIC
   CFLAGS += -fPIC
   LIBS += -fPIC
-  $(info $(MSG_PREFIX)Compiling position independent code)
-endif
-
-# whether to echo commands while building
-ifdef ABC_MAKE_VERBOSE
-  VERBOSE=
-else
-  VERBOSE=@
+  $(call abc_info,$(MSG_PREFIX)Compiling position independent code)
 endif
 
 # Set -Wno-unused-bug-set-variable for GCC 4.6.0 and greater only
@@ -120,16 +122,16 @@ GCC_VERSION=$(shell $(CC) -dumpversion)
 GCC_MAJOR=$(word 1,$(subst .,$(space),$(GCC_VERSION)))
 GCC_MINOR=$(word 2,$(subst .,$(space),$(GCC_VERSION)))
 
-$(info $(MSG_PREFIX)Found GCC_VERSION $(GCC_VERSION))
+$(call abc_info,$(MSG_PREFIX)Found GCC_VERSION $(GCC_VERSION))
 ifeq ($(findstring $(GCC_MAJOR),0 1 2 3),)
 ifeq ($(GCC_MAJOR),4)
-$(info $(MSG_PREFIX)Found GCC_MAJOR==4)
+$(call abc_info,$(MSG_PREFIX)Found GCC_MAJOR==4)
 ifeq ($(findstring $(GCC_MINOR),0 1 2 3 4 5),)
-$(info $(MSG_PREFIX)Found GCC_MINOR>=6)
+$(call abc_info,$(MSG_PREFIX)Found GCC_MINOR>=6)
 CFLAGS += -Wno-unused-but-set-variable
 endif
 else
-$(info $(MSG_PREFIX)Found GCC_MAJOR>=5)
+$(call abc_info,$(MSG_PREFIX)Found GCC_MAJOR>=5)
 CFLAGS += -Wno-unused-but-set-variable
 endif
 endif
@@ -148,10 +150,10 @@ endif
 
 ifdef ABC_USE_LIBSTDCXX
    LIBS += -lstdc++
-   $(info $(MSG_PREFIX)Using explicit -lstdc++)
+   $(call abc_info,$(MSG_PREFIX)Using explicit -lstdc++)
 endif
 
-$(info $(MSG_PREFIX)Using CFLAGS=$(CFLAGS))
+$(call abc_info,$(MSG_PREFIX)Using CFLAGS=$(CFLAGS))
 CXXFLAGS += $(CFLAGS) -std=c++17 -fno-exceptions
 
 SRC  :=


### PR DESCRIPTION
* introduce a user-defined function `abc_info` that only prints out text when ABC_MAKE_VERBOSE is set

* replace all calls to $(info ...) with calls to $(call abc_info, ...)

To show the output build with ABC_MAKE_VERBOSE. for example

```
make ABC_MAKE_VERBOSE=1 ...
```