### PR TITLE
Refactor(Cut): Explicit Comp

### DIFF
--- a/src/opt/cut/abcCut.c
+++ b/src/opt/cut/abcCut.c
@@ -324,7 +324,7 @@ printf( "Converged after %d iterations.\n", nIters );
 void * Abc_NodeGetCutsRecursive( void * p, Abc_Obj_t * pObj, int fDag, int fTree )
 {
     void * pList;
-    if ( pList = Abc_NodeReadCuts( p, pObj ) )
+    if ( (pList = Abc_NodeReadCuts( p, pObj )) != NULL )
         return pList;
     Abc_NodeGetCutsRecursive( p, Abc_ObjFanin0(pObj), fDag, fTree );
     Abc_NodeGetCutsRecursive( p, Abc_ObjFanin1(pObj), fDag, fTree );


### PR DESCRIPTION
Minor fix.
The old one is totally fine, but not friendly to developers. Changed to explicitly comparison.
```bash
Using the result of an assignment as a condition without parentheses (fixes available)clang(-Wparentheses)
```
