### PR TITLE
Fix assertion failure in `Abc_AigUpdateLevelR_int` during refactor/rewrite/resub 

### DIFF
--- a/src/base/abc/abcAig.c
+++ b/src/base/abc/abcAig.c
@@ -905,7 +905,7 @@ void Abc_AigReplace_int( Abc_Aig_t * pMan, Abc_Obj_t * pOld, Abc_Obj_t * pNew, i
             {
                 Abc_ObjSetReverseLevel( pFanin1, Abc_ObjReverseLevel(pOld) );
                 assert( pFanin1->fMarkB == 0 );
-                if ( !Abc_ObjIsCi(pFanin1) )
+                if ( !Abc_ObjIsCi(pFanin1) && !Abc_AigNodeIsConst(pFanin1) )
                 {
                     pFanin1->fMarkB = 1;
                     Vec_VecPush( pMan->vLevelsR, Abc_ObjReverseLevel(pFanin1), pFanin1 );
@@ -1139,7 +1139,7 @@ void Abc_AigUpdateLevelR_int( Abc_Aig_t * pMan )
             // iterate through the fanins
             Abc_ObjForEachFanin( pNode, pFanin, v )
             {
-                if ( Abc_ObjIsCi(pFanin) )
+                if ( Abc_ObjIsCi(pFanin) || Abc_AigNodeIsConst(pFanin) )
                     continue;
                 // get the new reverse level of this fanin
                 LevelNew = 0;


### PR DESCRIPTION
### Description
This PR fixes a long-standing assertion failure that occurs during logic synthesis commands such as `refactor`, `rewrite`, and `resub`. The crash happens when updating the reverse level of nodes.

**Fixes Issues:**
issue [#271](https://github.com/berkeley-abc/abc/issues/271)
issue [#451](https://github.com/berkeley-abc/abc/issues/451)
issue [#457](https://github.com/berkeley-abc/abc/issues/457)

### Error Log
When running specific benchmarks, the tool aborts with the following assertion error:
```
abc: src/base/abc/abcAig.c:1134: Abc_AigUpdateLevelR_int: Assertion `Abc_ObjIsNode(pNode)' failed.
Aborted (core dumped)
```

### Root Cause
The issue is located in the `Abc_AigUpdateLevelR_int` function. During the recursive update of reverse levels for fanin nodes, the function attempts to process all reachable nodes. However, it failed to filter out **constant nodes**.

When the traversal encounters a constant node, the assertion `Abc_ObjIsNode(pNode)` fails because a constant is not considered a standard logic node in this context. The fix ensures that constant nodes are skipped during the reverse level update.

### Reproduction Steps
The crash can be reproduced using the test cases provided in the related issues (files available [here](https://drive.google.com/drive/folders/151PUBEb07e28l_cevWocK2UuFK1Hp7uy)).

**Case 1:**
```bash
./abc -c "read int2float-24.aig; refactor"
```

**Case 2:**
```bash
./abc -c "read RISC.aig; rewrite"
```

**Case 3:**
```bash
./abc -c "read crash_retcode_case.blif; rewrite"
```

### Solution
Modified the traversal logic in `Abc_AigUpdateLevelR_int` to explicitly check for and skip constant nodes before attempting to access/update their reverse levels.
