### PR TITLE
Add explicit `#include <iterator>` to avoid transitive dependency

### DIFF
--- a/src/aig/gia/giaDecGraph.cpp
+++ b/src/aig/gia/giaDecGraph.cpp
@@ -38,6 +38,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <functional>
+#include <iterator>
 
 #include "gia.h"
 #include "misc/vec/vecHash.h"


### PR DESCRIPTION
Adding explicit `#include <iterator>` to avoid the transitive dependency on `<iterator>`