### PR TITLE
Make multiplications use unsigned to avoid UB on overflow

### DIFF
--- a/src/base/abc/abcAig.c
+++ b/src/base/abc/abcAig.c
@@ -90,10 +90,10 @@ struct Abc_Aig_t_
 static unsigned Abc_HashKey2( Abc_Obj_t * p0, Abc_Obj_t * p1, int TableSize ) 
 {
     unsigned Key = 0;
-    Key ^= Abc_ObjRegular(p0)->Id * 7937;
-    Key ^= Abc_ObjRegular(p1)->Id * 2971;
-    Key ^= Abc_ObjIsComplement(p0) * 911;
-    Key ^= Abc_ObjIsComplement(p1) * 353;
+    Key ^= (unsigned)Abc_ObjRegular(p0)->Id * 7937;
+    Key ^= (unsigned)Abc_ObjRegular(p1)->Id * 2971;
+    Key ^= (unsigned)Abc_ObjIsComplement(p0) * 911;
+    Key ^= (unsigned)Abc_ObjIsComplement(p1) * 353;
     return Key % TableSize;
 }
 


### PR DESCRIPTION
Had an Asan crash due to at least one of the inputs being an `int`. 

```
 third_party/abc/src/base/abc/abcAig.c:93:35: runtime error: signed integer overflow: 471230 * 7937 cannot be represented in type 'int'
     #0 0x556a5d67fc38 in Abc_AigAndCreate third_party/abc/src/base/abc/abcAig.c
     #1 0x556a5d67fc38 in abc::Abc_AigAnd(abc::Abc_Aig_t_*, abc::Abc_Obj_t_*, abc::Abc_Obj_t_*) third_party/abc/src/base/abc/abcAig.c:705:12
     #2 0x556a5d7d1e7d in abc::Abc_NodeStrash_rec(abc::Abc_Aig_t_*, abc::Hop_Obj_t_*) third_party/abc/src/base/abci/abcStrash.c:452:19
     #3 0x556a5d7d204e in abc::Abc_NodeStrash(abc::Abc_Ntk_t_*, abc::Abc_Obj_t_*, int) third_party/abc/src/base/abci/abcStrash.c:502:5
     #4 0x556a5d7d14bb in abc::Abc_NtkStrashPerform(abc::Abc_Ntk_t_*, abc::Abc_Ntk_t_*, int, int) third_party/abc/src/base/abci/abcStrash.c:429:31
     #5 0x556a5d7d12e1 in abc::Abc_NtkStrash(abc::Abc_Ntk_t_*, int, int, int) third_party/abc/src/base/abci/abcStrash.c:282:5
     #6 0x556a5d8682a8 in abc::Abc_CommandStrash(abc::Abc_Frame_t_*, int, char**) third_party/abc/src/base/abci/abc.c:3886:15
     #7 0x556a5d7ec914 in abc::CmdCommandDispatch(abc::Abc_Frame_t_*, int*, char***) third_party/abc/src/base/cmd/cmdUtils.c:157:14
     #8 0x556a5d7ec538 in abc::Cmd_CommandExecute(abc::Abc_Frame_t_*, char const*) third_party/abc/src/base/cmd/cmdApi.c:210:23
     #9 0x556a5dc9d4df in abc::CmdCommandSource(abc::Abc_Frame_t_*, int, char**) third_party/abc/src/base/cmd/cmd.c:795:22
     #10 0x556a5d7ec914 in abc::CmdCommandDispatch(abc::Abc_Frame_t_*, int*, char***) third_party/abc/src/base/cmd/cmdUtils.c:157:14
     #11 0x556a5d7ec538 in abc::Cmd_CommandExecute(abc::Abc_Frame_t_*, char const*) third_party/abc/src/base/cmd/cmdApi.c:210:23
     #12 0x556a5d65d693 in abc::Abc_RealMain(int, char**) third_party/abc/src/base/main/mainReal.c:371:23
```