### PR TITLE
Fix destructor rewireMiaig.h

### DIFF
--- a/src/opt/rar/rewireMiaig.h
+++ b/src/opt/rar/rewireMiaig.h
@@ -441,7 +441,7 @@ inline void Miaig::release(void) {
             if (_data->pRequire) free(_data->pRequire);
             if (_data->pTable) free(_data->pTable);
             if (_data->pNtkMapped) Vi_Free(_data->pNtkMapped);
-            delete _data;
+            free(_data);
         }
     }
 


### PR DESCRIPTION
Memory that is allocated with a C-style malloc should be deleted with free -- not with the C++-style delete.

Using delete here will cause runtime errors with toolchains that enforce using free for memory allocated with malloc.