### PR TITLE
Fix memory corruption in &mfs.

### DIFF
--- a/src/opt/sfm/sfmCnf.c
+++ b/src/opt/sfm/sfmCnf.c
@@ -111,8 +111,10 @@ int Sfm_TruthToCnf( word Truth, word * pTruth, int nVars, Vec_Int_t * vCover, Ve
         int i, k, c, RetValue, Literal, Cube, nCubes = 0;
         assert( nVars > 0 );
 
-        Abc_TtFlipVar5( &Truth, nVars );
-        Abc_TtFlipVar5( pTruth, nVars );
+        if ( nVars <= 6)
+            Abc_TtFlipVar5( &Truth, nVars );
+        else
+            Abc_TtFlipVar5( pTruth, nVars );
         for ( c = 0; c < 2; c ++ )
         {
             if ( nVars <= 6 )
@@ -148,7 +150,8 @@ int Sfm_TruthToCnf( word Truth, word * pTruth, int nVars, Vec_Int_t * vCover, Ve
                 Vec_StrPush( vCnf, (char)-1 );
             }
         }
-        Abc_TtFlipVar5( pTruth, nVars );
+        if (nVars > 6)
+            Abc_TtFlipVar5( pTruth, nVars );
 
         return nCubes;
     }


### PR DESCRIPTION
Calling `Abc_TtFlipVar5( &Truth, nVars )` when `nVars` is greater than 6 causes memory corruption because `Truth` only has storage for up to 6 variables.

This fix maintains the dichotomy between `Truth` and `pTruth` based on `nVars` that exists elsewhere in the function, thus removing the problem.