### PR TITLE
Fix &if crash after dch -f by leveling dangling choice nodes

### DIFF
--- a/src/aig/gia/giaIf.c
+++ b/src/aig/gia/giaIf.c
@@ -831,6 +831,10 @@ int Gia_ManChoiceLevel( Gia_Man_t * p )
             LevelMax = Gia_ObjLevel(p, pObj);
 //        Abc_Print( 1, "%d ", Gia_ObjLevel(p, pObj) );
     }
+    // compute levels for dangling nodes (can happen after choice-creating flows)
+    Gia_ManForEachAnd( p, pObj, i )
+        if ( !Gia_ObjIsTravIdCurrent( p, pObj ) )
+            Gia_ManChoiceLevel_rec( p, pObj );
 //    Abc_Print( 1, "\n" );
     Gia_ManForEachAnd( p, pObj, i )
         assert( Gia_ObjLevel(p, pObj) > 0 );
@@ -3257,4 +3261,3 @@ Gia_Man_t * Gia_ManDupHashMapping( Gia_Man_t * p )
 
 
 ABC_NAMESPACE_IMPL_END
-


### PR DESCRIPTION
This PR fixes a reproducible assertion failure in `Gia_ManChoiceLevel()` when running `&if` on AIGs containing choices introduced by `dch -f` (reported in #466).

##Root Cause
`dch -f` can introduce choices that leave some AND nodes dangling (not reachable from CO/CI). `Gia_ManChoiceLevel` only computes levels by traversing CO/CI, so dangling ANDs keep level 0 and trip the assert.

## Fix
Compute levels for any AND nodes that were not visited by the CO/CI traversal before the final assertion, so all ANDs have a valid level.

## Test
abc -c "ra i10.aig; strash; dch -f; &get; &if -K 6;"