### PR TITLE
Fix(&put): Missing spec in cec

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -34603,6 +34603,11 @@ int Abc_CommandAbc9Put( Abc_Frame_t * pAbc, int argc, char ** argv )
         Abc_NtkDelete( pNtkNoCh );
         Aig_ManStop( pMan );
     }
+    // transfer the spec name to the pNtk
+    if( pAbc->pGia->pSpec )
+    {
+        pNtk->pSpec = Extra_UtilStrsav( pAbc->pGia->pSpec );
+    }
     // transfer PI names to pNtk
     if ( pAbc->pGia->vNamesIn )
     {


### PR DESCRIPTION
A tiny fix.
We are missing the spec name after `&put`, which leads to
```bash
./abc -c "read_aiger i10.aig; strash; &get; &put; cec -n"
======== ABC command line "read_aiger i10.aig; strash; &get; &put; cec -n"
The external spec is not given.
```

After the fix:
```bash
./abc -c "read_aiger i10.aig; strash; &get; &put; cec -n"
======== ABC command line "read_aiger i10.aig; strash; &get; &put; cec -n"
Networks are equivalent after structural hashing.  Time =     0.00 sec
```