### PR TITLE
Fix backward required-time propagation through boxes

### DIFF
--- a/src/misc/tim/timTime.c
+++ b/src/misc/tim/timTime.c
@@ -249,7 +249,7 @@ float Tim_ManGetCoRequired( Tim_Man_t * p, int iCo )
         Tim_ManBoxForEachOutput( p, pBox, pObj, k )
         {
             pDelays = pTable + 3 + k * pBox->nInputs;
-            if ( pDelays[k] != -ABC_INFINITY )
+            if ( pDelays[i] != -ABC_INFINITY )
                 DelayBest = Abc_MinFloat( DelayBest, pObj->timeReq - pDelays[i] );
         }
         pObjRes->timeReq = DelayBest;


### PR DESCRIPTION
Two bugs in the backward required-time propagation through boxes are fixed:

 (1) Wrong index in Tim_ManGetCoRequired guard check (timTime.c:252): The connectivity check pDelays[k] used output index k instead of input index i, causing it to check the diagonal of the delay table rather than whether input i connects to output k. This also risked an out-of-bounds access when nOutputs > nInputs. 
Changed to pDelays[i] to match the computation on the following line and to be consistent with the forward code in Tim_ManGetCiArrival.

(2) Box output CIs assigned incorrect levels in Gia_ManDelayTraceLut (giaSpeedup.c): Gia_ManLevelNum assigns level 0 to all CIs, including box output CIs. This caused Gia_ManOrderReverse to process box output CIs after box input COs in the backward pass, so Tim_ManSetCiRequired had not yet been called when Tim_ManGetCoRequired needed the output required times. 

Fixed by updating box output CI levels to max(level of box input COs) + 1 after the forward timing pass, ensuring the correct backward ordering.

Testing
  - Verified both fixes compile cleanly
  - Tested with designs containing white boxes (e.g., Test16: PIs -> LUT -> 2-in/1-out box -> LUT -> PO)
  - Confirmed the warning "Tim_ManGetCoRequired(): Output required times of output 0 the box 0 are not up to date!" no longer appears
  - No change in output of old box test cases versus current ABC (but there were changes compared to old .txt files that came with the test cases)
