### PR TITLE
Fix two bugs causing problems with &trace and boxes.

### DIFF
--- a/src/aig/gia/giaSpeedup.c
+++ b/src/aig/gia/giaSpeedup.c
@@ -350,7 +350,7 @@ float Gia_ManDelayTraceLut( Gia_Man_t * p )
             int j, maxLevel = 0;
             for ( j = 0; j < nIns; j++ )
             {
-                int coLevel = Gia_ObjLevel( p, Gia_ManCo(p, iCoFirst + j) );
+                int coLevel = Gia_ObjLevel( p, Gia_ObjFanin0(Gia_ManCo(p, iCoFirst + j)) );
                 if ( coLevel > maxLevel )
                     maxLevel = coLevel;
             }


### PR DESCRIPTION
Fix two bugs causing problems in &trace with boxes

Fork: jon-greene/abc
Branch: fix-req-time-with-boxes

Changed files:
  src/aig/gia/giaSpeedup.c
  src/aig/gia/giaAiger.c

BUG 1: Tim_ManGetCoRequired warning
------------------------------------

Symptom:
  When running &trace on designs with cascading boxes (two or more boxes
  connected in series), the following warning is printed:
    Tim_ManGetCoRequired(): Output required times of output 0 the box 1
    are not up to date!

Cause:
  In Gia_ManDelayTraceLut() (giaSpeedup.c), the box output CI level
  correction loop reads the CO object level:

    int coLevel = Gia_ObjLevel( p, Gia_ManCo(p, iCoFirst + j) );

  But the CO object level was set by Gia_ManLevelNum before the CI level
  corrections ran. For a box input CO whose fanin is a previous box's
  output CI, the CO object level is stale (based on the CI's pre-correction
  level of 0).

  Example with two cascading boxes: Box 0's output CI w1 gets corrected
  to level 3, but Box 1's input CO for w1 still has object level 0.
  Box 1's output CI w2 then gets level 1 (maxLevel 0 + 1) instead of
  level 4. In Gia_ManOrderReverse, w2 at level 1 is processed after
  CO(w1->box1) at fanin level 3, causing Tim_ManGetCoRequired to find
  that w2's required time has not been set yet.

Fix:
  Read the CO's fanin level instead of the CO object level:

    int coLevel = Gia_ObjLevel( p, Gia_ObjFanin0(Gia_ManCo(p, iCoFirst + j)) );

  The fanin level reflects any prior CI corrections, so cascading boxes
  pick up the corrected levels and their output CIs are placed at high
  enough levels in Gia_ManOrderReverse.

BUG 2: XAIG ReqTime sentinel value
------------------------------------

Symptom:
  The output XAIG file contains ReqTime = 1000000000 (TIM_ETERNITY) for
  unconstrained outputs. Per the XAIG spec, unconstrained required times
  should be written as -1.0.

Cause:
  In Gia_AigerWriteSimple() (giaAiger.c), Tim_ManGetReqTimes() returns
  raw float values which may contain TIM_ETERNITY (1000000000). The code
  writes these directly to the file via fwrite without converting them
  to the XAIG spec's -1.0 sentinel.

Fix:
  Write side (extension "o"): After Tim_ManGetReqTimes() and before
  fwrite(), convert any values >= TIM_ETERNITY to -1.0.

  Read side (extension "o"): After reading the required time array,
  convert any values < 0 back to TIM_ETERNITY for internal use.
