### PR TITLE
Fix required time handling for unconstrained POs, infinity arithmetic, and cosmetic problem in absDup.c

### DIFF
--- a/src/aig/gia/giaSpeedup.c
+++ b/src/aig/gia/giaSpeedup.c
@@ -209,6 +209,9 @@ float Gia_ObjPropagateRequired( Gia_Man_t * p, int iObj, int fUseSorting )
     float tRequired = 0.0; // Suppress "might be used uninitialized"
     float * pDelays;
     assert( Gia_ObjIsLut(p, iObj) );
+    // Infinity propagates unchanged
+    if ( Gia_ObjTimeRequired( p, iObj ) >= TIM_ETERNITY )
+        return TIM_ETERNITY;
     if ( pLutLib == NULL && pCellLib == NULL )
     {
         tRequired = Gia_ObjTimeRequired( p, iObj) - (float)1.0;
@@ -407,9 +410,11 @@ float Gia_ManDelayTraceLut( Gia_Man_t * p )
         }
 
         // set slack for this object
-        tSlack = Gia_ObjTimeRequired(p, iObj) - Gia_ObjTimeArrival(p, iObj);
-        assert( tSlack + 0.01 > 0.0 );
-        Gia_ObjSetTimeSlack( p, iObj, tSlack < 0.0 ? 0.0 : tSlack );
+        if ( Gia_ObjTimeRequired(p, iObj) >= TIM_ETERNITY )
+            tSlack = TIM_ETERNITY;
+        else
+            tSlack = Gia_ObjTimeRequired(p, iObj) - Gia_ObjTimeArrival(p, iObj);
+        Gia_ObjSetTimeSlack( p, iObj, tSlack );
     }
     Vec_IntFree( vObjs );
     return tArrival;

--- a/src/misc/tim/timTime.c
+++ b/src/misc/tim/timTime.c
@@ -98,6 +98,11 @@ void Tim_ManInitPoRequiredAll( Tim_Man_t * p, float Delay )
 {
     Tim_Obj_t * pObj;
     int i;
+    // If any PO or flop-input CO is constrained, leave all unchanged
+    Tim_ManForEachPo( p, pObj, i )
+        if ( pObj->timeReq < TIM_ETERNITY )
+            return;
+    // All unconstrained — set to max arrival time
     Tim_ManForEachPo( p, pObj, i )
         Tim_ManSetCoRequired( p, i, Delay );
 }
@@ -249,7 +254,7 @@ float Tim_ManGetCoRequired( Tim_Man_t * p, int iCo )
         Tim_ManBoxForEachOutput( p, pBox, pObj, k )
         {
             pDelays = pTable + 3 + k * pBox->nInputs;
-            if ( pDelays[i] != -ABC_INFINITY )
+            if ( pDelays[i] != -ABC_INFINITY && pObj->timeReq < TIM_ETERNITY )
                 DelayBest = Abc_MinFloat( DelayBest, pObj->timeReq - pDelays[i] );
         }
         pObjRes->timeReq = DelayBest;

--- a/src/proof/abs/absDup.c
+++ b/src/proof/abs/absDup.c
@@ -303,7 +303,7 @@ void Gia_ManPrintFlopClasses( Gia_Man_t * p )
     int Counter0, Counter1;
     if ( p->vFlopClasses == NULL )
         return;
-    if ( Vec_IntSize(p->vFlopClasses) != Gia_ManRegNum(p) )
+    if ( Vec_IntSize(p->vFlopClasses) != Gia_ManRegBoxNum(p) )
     {
         printf( "Gia_ManPrintFlopClasses(): The number of flop map entries differs from the number of flops.\n" );
         return;
@@ -312,7 +312,7 @@ void Gia_ManPrintFlopClasses( Gia_Man_t * p )
     Counter1 = Vec_IntCountEntry( p->vFlopClasses, 1 );
     printf( "Flop-level abstraction:  Excluded FFs = %d  Included FFs = %d  (%.2f %%) ", 
         Counter0, Counter1, 100.0*Counter1/(Counter0 + Counter1 + 1) );
-    if ( Counter0 + Counter1 < Gia_ManRegNum(p) )
+    if ( Counter0 + Counter1 < Gia_ManRegBoxNum(p) )
         printf( "and there are other FF classes..." );
     printf( "\n" );
 }


### PR DESCRIPTION
Branch: fix-req-time-infinity
Affected files:
  src/misc/tim/timTime.c
  src/misc/tim/timMan.c
  src/aig/gia/giaSpeedup.c
  src/proof/abs/absDup.c

-------------------
Short overall summary from Claude:

- Tim_ManInitPoRequiredAll: only overwrite PO required times when ALL are unconstrained; preserve user-specified constraints
- Gia_ObjPropagateRequired: propagate infinity unchanged through LUTs
- Tim_ManGetCoRequired: guard against infinity minus delay arithmetic
- Gia_ManDelayTraceLut: handle infinite required times in slack computation; allow negative slack to report timing violations
- Tim_ManCreate: fix required-time loading to address actual POs via Tim_ManForEachPo instead of p->pCos[] (wrong for designs with boxes)
- Tim_ManGetArrTimes/Tim_ManGetReqTimes: fix loop-exit detection using boolean flag instead of comparing iterator index against PO/PI count
- Gia_ManPrintFlopClasses: use Gia_ManRegBoxNum instead of Gia_ManRegNum

----------------------------------------------------------------------
Problem 1: Tim_ManInitPoRequiredAll overwrites user-specified required times

Summary:
  Tim_ManInitPoRequiredAll() unconditionally sets all PO required times
  to the max arrival time. When a design has user-specified required time
  constraints (e.g., ReqTime=500 on a PO), these are destroyed.

Diagnosis:
  The function is called during backward timing propagation and blindly
  overwrites every PO/flop-input CO required time with the computed max
  arrival delay, regardless of whether user constraints exist.

Fix (timTime.c, Tim_ManInitPoRequiredAll):
  Added an early-return guard: scan all POs and flop-input COs via
  Tim_ManForEachPo; if any has a required time less than TIM_ETERNITY
  (i.e., is constrained), return immediately without overwriting.
  Only set required times to max arrival when ALL are unconstrained.

----------------------------------------------------------------------
Problem 2: Infinity arithmetic produces incorrect values during backward propagation

Summary:
  When a PO has unconstrained required time (TIM_ETERNITY = 1e9), backward
  propagation through LUTs and boxes subtracts delays from infinity,
  producing large finite values instead of preserving infinity.

Diagnosis:
  In Gia_ObjPropagateRequired (giaSpeedup.c), subtracting a LUT delay
  from TIM_ETERNITY yields a large finite number that pollutes downstream
  required times. Similarly, in Tim_ManGetCoRequired (timTime.c), the
  expression pObj->timeReq - pDelays[i] computes infinity minus a box
  delay, again producing a large finite value.

Fix (giaSpeedup.c, Gia_ObjPropagateRequired):
  Added an early return at the top of the function: if the LUT's required
  time is >= TIM_ETERNITY, return TIM_ETERNITY immediately without
  subtracting any delay.

Fix (timTime.c, Tim_ManGetCoRequired):
  Added a guard on the inner loop condition: only compute
  pObj->timeReq - pDelays[i] when pObj->timeReq < TIM_ETERNITY.
  If the box output is unconstrained, DelayBest stays at TIM_ETERNITY.

----------------------------------------------------------------------
Problem 3: Slack computation asserts on negative slack from user constraints

Summary:
  When user-specified required times are preserved (per Problem 1 fix),
  some COs may have required time less than their arrival time, producing
  negative slack. The existing assertion (tSlack + 0.01 > 0.0) fails.

Diagnosis:
  Tests 20_apex4 and 20_s298 have a user constraint of ReqTime=500 on
  COs whose arrival times exceed 500 (e.g., arrival=1056). This is a
  valid scenario where the design does not meet timing. Negative slack
  should be clamped to zero, not trigger an assertion.

Fix (giaSpeedup.c, Gia_ManDelayTraceLut):
  Removed the assertion and the clamping of negative slack to zero.
  Added a guard: if required time >= TIM_ETERNITY, set slack to
  TIM_ETERNITY; otherwise compute slack normally. Negative slack is
  now reported as-is, so the user can see by how much timing was missed.

----------------------------------------------------------------------
Problem 4: Required times loaded to wrong COs in Tim_ManCreate

Summary:
  When extension O provides required times for POs only (fewer entries
  than the total CO count), the values are stored on the wrong COs.
  For example, Test15 has ReqTime=500 for the PO, but after loading,
  the PO shows TIM_ETERNITY (the default).

Diagnosis:
  Tim_ManCreate used p->pCos[i] to store the i-th required time entry.
  In designs with boxes, POs are at the END of the CO array (after box
  input COs), so p->pCos[0] addresses a box input CO, not the first PO.
  The required time of 500 was written to a box input CO instead of
  the actual PO.

Fix (timMan.c, Tim_ManCreate):
  Changed the required-time loading loop to use Tim_ManForEachPo to
  iterate over actual POs. This correctly maps extension O entries
  to POs regardless of their position in the CO array. Also changed
  the size check from < to <= to handle the case where extension O
  has exactly Tim_ManPoNum entries.

----------------------------------------------------------------------
Problem 5: Tim_ManGetArrTimes/Tim_ManGetReqTimes use wrong loop exit test

Summary:
  After the Tim_ManForEachPo/Pi scan loop, the code compared loop
  variable i against Tim_ManPoNum(p)/Tim_ManPiNum(p) to detect whether
  any timing was found. This comparison is incorrect for designs with
  boxes.

Diagnosis:
  Tim_ManForEachPo iterates ALL COs (i = 0..nCos-1), filtering for
  those with iObj2Box < 0. When the loop completes without breaking,
  i equals p->nCos, not Tim_ManPoNum(p). So the comparison
  i == Tim_ManPoNum(p) is wrong whenever nCos != Tim_ManPoNum(p)
  (i.e., any design with boxes). Similarly for Tim_ManForEachPi.
  This caused the functions to incorrectly report that timing
  constraints exist when they don't, or vice versa.

Fix (timMan.c, Tim_ManGetArrTimes and Tim_ManGetReqTimes):
  Replaced the loop-exit index comparison with a boolean flag
  (fFoundTiming / fFoundConstraint). The flag is set to 1 inside the
  loop body when a non-default value is found, and checked after the
  loop instead of comparing the index variable.

----------------------------------------------------------------------
Problem 6: Gia_ManPrintFlopClasses uses wrong register count (cosmetic)

Summary:
  Gia_ManPrintFlopClasses compares vFlopClasses size against
  Gia_ManRegNum(p), which counts AIGER latches. For designs using
  box-modeled flops, Gia_ManRegNum(p) is 0, causing the function
  to silently return without printing.

Diagnosis:
  Box-modeled flops are counted by Gia_ManRegBoxNum(p) (from
  vRegClasses), not Gia_ManRegNum(p). The size check and the
  subsequent count check both used the wrong accessor.

Fix (absDup.c, Gia_ManPrintFlopClasses):
  Replaced Gia_ManRegNum(p) with Gia_ManRegBoxNum(p) in both the
  size check and the Counter0+Counter1 comparison.
