### PR TITLE
Fix WASI and make prototype valid (from YosysHQ fork)

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -18,6 +18,7 @@
 
 ***********************************************************************/
 
+#include <inttypes.h>
 #include "base/abc/abc.h"
 #include "base/main/main.h"
 #include "base/main/mainInt.h"
@@ -59854,7 +59855,7 @@ int Abc_CommandAbc9eSLIM( Abc_Frame_t * pAbc, int argc, char ** argv ) {
 }
 
 int Abc_CommandAbc9CatBtor( Abc_Frame_t * pAbc, int argc, char ** argv ) {
-    extern void Abc_BtorCat( char * pFileName, int fVerbose );
+    extern int32_t Abc_BtorCat( char * pFileName, int fVerbose );
   
     int c, fVerbose = 0;
     char * pFileName;
@@ -59877,9 +59878,7 @@ int Abc_CommandAbc9CatBtor( Abc_Frame_t * pAbc, int argc, char ** argv ) {
         return 0;
     }
 
-    Abc_BtorCat( pFileName, fVerbose );
-    
-    return 0;
+    return Abc_BtorCat( pFileName, fVerbose );
 
 usage:
     Abc_Print( -2, "usage: &catbtor [-v] <file>\n" );

--- a/src/opt/untk/NtkNtk.cpp
+++ b/src/opt/untk/NtkNtk.cpp
@@ -1273,7 +1273,11 @@ static inline int run_external_solver_on_aig( Abc_Ntk_t * pAbcNtk, const string&
         command += " " + to_string(nRuntimeLimitSec);
     command += " > log.txt 2>&1";
     LOG(1) << "UFAR external solver: launching command instead of PDR: " << command;
+#ifdef __wasm
+    int res = -1;
+#else
     int res = system( command.c_str() );
+#endif 
     std::remove( pAigFile );
     return res;
 }


### PR DESCRIPTION
Abc_BtorCat function prototype is invalid and that causes issues linking with some compilers.

This also makes WASI build to compile, returning error since system call is unavailable on platform. 