### PR TITLE
Makefile: Respect LDFLAGS when linking shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ lib$(PROG).a: $(LIBOBJ)
 
 lib$(PROG).so: $(LIBOBJ)
 	@echo "$(MSG_PREFIX)\`\` Linking:" $(notdir $@)
-	$(VERBOSE)$(CXX) -shared -o $@ $^ $(LIBS)
+	$(VERBOSE)$(CXX) -shared -o $@ $^ $(LDFLAGS) $(LIBS)
 
 docs:
 	@echo "$(MSG_PREFIX)\`\` Building documentation." $(notdir $@)


### PR DESCRIPTION
LDFLAGS is taken into account when linking the executable, but not the shared library, which is inconsistent and may cause issues if customized settings are passed through LDFLAGS (for example, LTO). Let's include LDFLAGS in the linking command.

Fixes: b9dfb992c78e ("(1) Makefile: added a shared library target, (2) no longer compile the main function as part of libabc.a")