### PR TITLE
Provide replacement value for PATH_MAX on platforms without it.

### DIFF
--- a/src/misc/extra/extraUtilFile.c
+++ b/src/misc/extra/extraUtilFile.c
@@ -23,6 +23,9 @@
 #define PATH_MAX MAX_PATH
 #else
 #include <limits.h>
+#  ifndef PATH_MAX
+#    define PATH_MAX 4096
+#  endif
 #endif
 
 #include "extra.h"


### PR DESCRIPTION
The buffer length is used in a static array returned from Extra_FileNameGenericAppend(), used many places in the code, and a more dynamic approach would require a huge refactoring.  There is no guarantee that the 4096 value picked is large enough, but it matches common values found on Linux.