### PR TITLE
Relaxed assert in Io_WritePla() to avoid failure with too shallow network.

### DIFF
--- a/src/base/io/ioWritePla.c
+++ b/src/base/io/ioWritePla.c
@@ -174,7 +174,7 @@ int Io_WritePla( Abc_Ntk_t * pNtk, char * pFileName )
     FILE * pFile;
 
     assert( Abc_NtkIsSopNetlist(pNtk) );
-    assert( Abc_NtkLevel(pNtk) == 1 );
+    assert( Abc_NtkLevel(pNtk) <= 1 );
 
     pFile = fopen( pFileName, "w" );
     if ( pFile == NULL )


### PR DESCRIPTION
Otherwise the abc will refuse to output trivial functions(constant 1 or 0).

The issue was originally submitted to
<URL: https://bitbucket.org/alanmi/abc/issue/27/assertion-failure-in-write_pla-command >, now available via
<URL: https://web.archive.org/web/20200621081236/https://bitbucket.org/alanmi/abc/issues/27/assertion-failure-in-write_pla-command >. Sadly the example demonstrating the problem was not archived.

This issue was also reported as <URL: https://bugs.debian.org/780450 >.