### PR TITLE
Fix intermittent assert failures in lutpack functions

### DIFF
--- a/src/opt/lpk/lpkCut.c
+++ b/src/opt/lpk/lpkCut.c
@@ -197,7 +197,7 @@ unsigned * Lpk_CutTruth( Lpk_Man_t * p, Lpk_Cut_t * pCut, int fInv )
         // set the initial truth tables at the fanins
         Abc_ObjForEachFanin( pObj, pFanin, k )
         {
-            assert( ((unsigned)(ABC_PTRUINT_T)pFanin->pCopy) & 0xffff0000 );
+            assert( ((ABC_PTRUINT_T)pFanin->pCopy) > 0xffff ); // catch small int values or NULL
             Hop_ManPi( pManHop, k )->pData = pFanin->pCopy;
         }
         // compute the truth table of internal nodes

--- a/src/opt/lpk/lpkCut.c
+++ b/src/opt/lpk/lpkCut.c
@@ -141,7 +141,7 @@ unsigned * Lpk_CutTruth_rec( Hop_Man_t * pMan, Hop_Obj_t * pObj, int nVars, Vec_
     assert( !Hop_IsComplement(pObj) );
     if ( pObj->pData )
     {
-        assert( ((unsigned)(ABC_PTRUINT_T)pObj->pData) & 0xffff0000 );
+        assert( ((ABC_PTRUINT_T)pObj->pData) > 0xffff ); // catch small int values
         return (unsigned *)pObj->pData;
     }
     // get the plan for a new truth table


### PR DESCRIPTION
The assert on line 200 causes intermittent failures for FPGA flows ([as seen here](https://github.com/YosysHQ/yosys/issues/1028)). The assert is checking that pData doesn't hold a "small integer value" (<= 0xFFFF) which is a valid defensive check.  
However, the check casts pData (8B on 64-bit) through ABC_PTRUINT_T to unsigned, which truncates the high 32 bits.
When pData is a valid pointer to data allocated at or above 4 GB boundaries, this assert is triggered because the high bits are non-zero but the lower 32 bits can be near zero.
This fix preserves the original intent and is safe on 32-bit and 64-bit platforms.