### PR TITLE
mainUtils: match readline behavior when ABC_USE_READLINE is undefined

### DIFF
--- a/src/base/main/mainUtils.c
+++ b/src/base/main/mainUtils.c
@@ -18,6 +18,8 @@
 
 ***********************************************************************/
 
+#include <unistd.h>
+
 #include "base/abc/abc.h"
 #include "mainInt.h"
 
@@ -91,7 +93,13 @@ char * Abc_UtilsGetUsersInput( Abc_Frame_t * pAbc )
     {
     char * pRetValue;
     fprintf( pAbc->Out, "%s", Prompt );
+    fflush( pAbc->Out );
     pRetValue = fgets( Prompt, 5000, stdin );
+    if ( pRetValue == NULL ) { exit(0); }
+    if ( !isatty( fileno(stdin) ) ) {
+        fputs( Prompt, pAbc->Out );
+        fflush( pAbc->Out );
+    }
     return Prompt;
     }
 #endif


### PR DESCRIPTION
The non-readline branch of `Abc_UtilsGetUsersInput` has three behavioral gaps
versus the readline branch that break callers driving abc as a coprocess
over a pipe — notably yosys's `passes/techmap/abc.cc`, which spawns `abc -s`
with piped stdin/stdout and uses `read_until_abc_done` to wait for
`abc NN> <command>` lines:

1. **Missing flush on the prompt.** The prompt is written with `fprintf()`
   and never flushed. On a pipe stdout is fully buffered, so the prompt
   never reaches the reader. The reader waits for the prompt, abc waits
   in `fgets()`, deadlock.

2. **No echo of input.** `readline()` emits each character to its output
   stream; yosys's protocol depends on seeing `abc NN> source ...\n` in
   the output to advance state. Without an echo it waits forever.

3. **EOF ignored.** When stdin closes, `fgets()` returns NULL but the
   function returns a stale `Prompt` buffer, causing a tight loop on pipe
   close. The readline branch `exit(0)`s on NULL.

This patch fixes all three. The echo is gated on `!isatty(fileno(stdin))`
because on a tty the kernel already echoes during cooked input, and a
double echo would be visible to interactive users.

### Reproduction

Without the patch, with an ABC_USE_READLINE=0 build:

~~~
$ printf 'version\nquit\n' | ./abc -s
UC Berkeley, ABC 1.01 ...
abc 01> UC Berkeley, ABC 1.01 ...
~~~

The prompt appears (only because the pipe drained on exit, not on
flush) and the input is never echoed. yosys, which expects to see
\`abc 01> source <script>\` in the stream, hangs in \`read()\`.

With the patch, the same invocation produces:

~~~
$ printf 'version\nquit\n' | ./abc -s
UC Berkeley, ABC 1.01 ...
abc 01> version
UC Berkeley, ABC 1.01 ...
abc 02> quit
~~~

which matches the output stream readline produces on the same input, and
unblocks yosys's coprocess driver.