### PR TITLE
Windows cleanup

### DIFF
--- a/.github/scripts/abcexe.vcxproj
+++ b/.github/scripts/abcexe.vcxproj
@@ -33,6 +33,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <DisableSpecificWarnings>4146;4334;4996;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <TreatSpecificWarningsAsErrors>4013</TreatSpecificWarningsAsErrors>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/.github/scripts/abclib.vcxproj.template
+++ b/.github/scripts/abclib.vcxproj.template
@@ -32,6 +32,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <DisableSpecificWarnings>4146;4334;4996;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <TreatSpecificWarningsAsErrors>4013</TreatSpecificWarningsAsErrors>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/src/base/abci/abcNpn.c
+++ b/src/base/abci/abcNpn.c
@@ -319,10 +319,6 @@ void Abc_TruthNpnPerform( Abc_TtStore_t * p, int NpnType, int fVerbose )
     }
     else if ( NpnType == 8 )
     {
-//        typedef unsigned(*TtCanonicizeFunc)(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int flag);
-        unsigned Abc_TtCanonicizeWrap(TtCanonicizeFunc func, Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int flag);
-        unsigned Abc_TtCanonicizeAda(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int iThres);
-		
 		int fHigh = 1, iEnumThres = 25;
 		Abc_TtHieMan_t * pMan = Abc_TtHieManStart(p->nVars, 5);
 		for ( i = 0; i < p->nFuncs; i++ )
@@ -337,11 +333,6 @@ void Abc_TruthNpnPerform( Abc_TtStore_t * p, int NpnType, int fVerbose )
     }
     else if ( NpnType == 9 || NpnType == 10 || NpnType == 11 )
     {
-//        typedef unsigned(*TtCanonicizeFunc)(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int flag);
-        unsigned Abc_TtCanonicizeWrap(TtCanonicizeFunc func, Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int flag);
-        unsigned Abc_TtCanonicizeAda(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int iThres);
-        unsigned Abc_TtCanonicizeCA(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int iThres);
-		
 		Abc_TtHieMan_t * pMan = Abc_TtHieManStart(p->nVars, 5);
 		for ( i = 0; i < p->nFuncs; i++ )
         {

--- a/src/base/main/mainUtils.c
+++ b/src/base/main/mainUtils.c
@@ -20,6 +20,7 @@
 
 #ifdef WIN32
 #include <process.h> 
+#include <io.h>
 #else
 #include <unistd.h>
 #endif

--- a/src/opt/dau/dau.h
+++ b/src/opt/dau/dau.h
@@ -86,6 +86,7 @@ extern Abc_TtHieMan_t * Abc_TtHieManStart( int nVars, int nLevels );
 extern void          Abc_TtHieManStop(Abc_TtHieMan_t * p );
 extern unsigned      Abc_TtCanonicizeWrap(TtCanonicizeFunc func, Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int flag);
 extern unsigned      Abc_TtCanonicizeAda(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int iThres);
+extern unsigned      Abc_TtCanonicizeCA(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int fCA);
 extern unsigned      Abc_TtCanonicizeHie(Abc_TtHieMan_t * p, word * pTruthInit, int nVars, char * pCanonPerm, int fExact);
 /*=== dauCount.c ==========================================================*/
 extern int           Abc_TtCountOnesInCofsQuick( word * pTruth, int nVars, int * pStore );

--- a/src/opt/dau/dauNpn.c
+++ b/src/opt/dau/dauNpn.c
@@ -1082,7 +1082,6 @@ Vec_Mem_t * Dau_CollectNpnFunctionsArray( Vec_Wrd_t * vFuncs, int nVars, Vec_Int
 void Dau_CanonicizeArray( Vec_Wrd_t * vFuncs, int nVars, int fVerbose )
 {
     abctime clkStart  = Abc_Clock();
-    extern unsigned Abc_TtCanonicizeCA(Abc_TtHieMan_t * p, word * pTruth, int nVars, char * pCanonPerm, int iThres);
     if ( fVerbose )   printf( "Functions: %d (original) ", Vec_WrdSize(vFuncs) );
     unsigned uCanonPhase; char pCanonPerm[16]; word Func; int i;
     Vec_WrdUniqify( vFuncs );

--- a/src/sat/kissat/colors.c
+++ b/src/sat/kissat/colors.c
@@ -1,6 +1,7 @@
 #include "colors.h"
 
 #if defined(WIN32) && !defined(__MINGW32__)
+#include <io.h>
 #define isatty _isatty
 #else
 #include <unistd.h>

--- a/src/sat/kissat/file.c
+++ b/src/sat/kissat/file.c
@@ -9,10 +9,12 @@
 #include <sys/types.h>
 
 #ifdef WIN32
+#include <io.h>
 #define unlink _unlink
 #define access _access
 #define R_OK 4
 #define W_OK 2
+#define	S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
While working on making ABC build with CMake under yosys environment, noticed these couple of issues.
Very strange is that it builds currently on CI but it should really fail with missing io.h and some of defines.
There was also linking issue related to Abc_TtCanonicizeCA (due to namespace) so added that to .h as other calls and cleaned unneeded extern now.