### PR TITLE
Fix strict aliasing violations

### DIFF
--- a/src/aig/hop/hop.h
+++ b/src/aig/hop/hop.h
@@ -233,7 +233,7 @@ static inline Hop_Obj_t * Hop_ManFetchMemory( Hop_Man_t * p )
     if ( p->pListFree == NULL )
         Hop_ManAddMemory( p );
     pTemp = p->pListFree;
-    p->pListFree = *((Hop_Obj_t **)pTemp);
+    memcpy(&p->pListFree, pTemp, sizeof(Hop_Obj_t *));
     memset( pTemp, 0, sizeof(Hop_Obj_t) ); 
     if ( p->vObjs )
     {
@@ -245,8 +245,8 @@ static inline Hop_Obj_t * Hop_ManFetchMemory( Hop_Man_t * p )
 }
 static inline void Hop_ManRecycleMemory( Hop_Man_t * p, Hop_Obj_t * pEntry )
 {
-    pEntry->Type = AIG_NONE; // distinquishes dead node from live node
-    *((Hop_Obj_t **)pEntry) = p->pListFree;
+    pEntry->Type = AIG_NONE; // distinguishes dead node from live node
+    memcpy(pEntry, &p->pListFree, sizeof(Hop_Obj_t *));
     p->pListFree = pEntry;
 }
 

--- a/src/aig/hop/hopMem.c
+++ b/src/aig/hop/hopMem.c
@@ -88,14 +88,16 @@ void Hop_ManStopMemory( Hop_Man_t * p )
 ***********************************************************************/
 void Hop_ManAddMemory( Hop_Man_t * p )
 {
-    char * pMemory;
+    Hop_Obj_t * pMemory;
+    char *PMemAlign = 0;
     int i, nBytes;
     assert( sizeof(Hop_Obj_t) <= 64 );
     assert( p->pListFree == NULL );
 //    assert( (Hop_ManObjNum(p) & IVY_PAGE_MASK) == 0 );
     // allocate new memory page
     nBytes = sizeof(Hop_Obj_t) * (1<<IVY_PAGE_SIZE) + 64;
-    pMemory = ABC_ALLOC( char, nBytes );
+    PMemAlign = PMemAlign + 64 - (((int)(ABC_PTRUINT_T)PMemAlign) & 63);
+    pMemory = (Hop_Obj_t *)PMemAlign;
     Vec_PtrPush( p->vChunks, pMemory );
     // align memory at the 32-byte boundary
     pMemory = pMemory + 64 - (((int)(ABC_PTRUINT_T)pMemory) & 63);
@@ -105,10 +107,12 @@ void Hop_ManAddMemory( Hop_Man_t * p )
     p->pListFree = (Hop_Obj_t *)pMemory;
     for ( i = 1; i <= IVY_PAGE_MASK; i++ )
     {
-        *((char **)pMemory) = pMemory + sizeof(Hop_Obj_t);
-        pMemory += sizeof(Hop_Obj_t);
+        Hop_Obj_t *NextPtr = pMemory + 1;
+        memcpy(pMemory, &NextPtr, sizeof(Hop_Obj_t *));
+        pMemory += 1;
     }
-    *((char **)pMemory) = NULL;
+    Hop_Obj_t *NullPtr = NULL;
+    memcpy(pMemory, &NullPtr, sizeof(Hop_Obj_t *));
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/aig/hop/hopMem.c
+++ b/src/aig/hop/hopMem.c
@@ -88,31 +88,32 @@ void Hop_ManStopMemory( Hop_Man_t * p )
 ***********************************************************************/
 void Hop_ManAddMemory( Hop_Man_t * p )
 {
-    Hop_Obj_t * pMemory;
-    char *PMemAlign = 0;
+    char * pMemory = 0;
+    Hop_Obj_t * pEntry, * pNext;
     int i, nBytes;
     assert( sizeof(Hop_Obj_t) <= 64 );
     assert( p->pListFree == NULL );
 //    assert( (Hop_ManObjNum(p) & IVY_PAGE_MASK) == 0 );
     // allocate new memory page
     nBytes = sizeof(Hop_Obj_t) * (1<<IVY_PAGE_SIZE) + 64;
-    PMemAlign = PMemAlign + 64 - (((int)(ABC_PTRUINT_T)PMemAlign) & 63);
-    pMemory = (Hop_Obj_t *)PMemAlign;
+    pMemory = pMemory + 64 - (((int)(ABC_PTRUINT_T)pMemory) & 63);
+    pMemory = ABC_ALLOC( char, nBytes );
     Vec_PtrPush( p->vChunks, pMemory );
     // align memory at the 32-byte boundary
     pMemory = pMemory + 64 - (((int)(ABC_PTRUINT_T)pMemory) & 63);
     // remember the manager in the first entry
     Vec_PtrPush( p->vPages, pMemory );
     // break the memory down into nodes
-    p->pListFree = (Hop_Obj_t *)pMemory;
+    pEntry = (Hop_Obj_t *)pMemory;
+    p->pListFree = pEntry;
     for ( i = 1; i <= IVY_PAGE_MASK; i++ )
     {
-        Hop_Obj_t *NextPtr = pMemory + 1;
-        memcpy(pMemory, &NextPtr, sizeof(Hop_Obj_t *));
-        pMemory += 1;
+        pNext = pEntry + 1;
+        memcpy( pEntry, &pNext, sizeof(Hop_Obj_t *) );
+        pEntry++;
     }
-    Hop_Obj_t *NullPtr = NULL;
-    memcpy(pMemory, &NullPtr, sizeof(Hop_Obj_t *));
+    pNext = NULL;
+    memcpy( pEntry, &pNext, sizeof(Hop_Obj_t *) );
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The cast to char** is a violation of strict aliasing rules. Compilers may generate incorrect code due to this issue. Using memcpy to avoid the issue. Not expecting perf difference.

This was found via testing in SPEC CPU's 729.abc_r.