### PR TITLE
Fix(rand): UB on different platform

### DIFF
--- a/src/aig/gia/giaCut.c
+++ b/src/aig/gia/giaCut.c
@@ -690,7 +690,7 @@ Vec_Wec_t * Gia_ManSelectCuts( Vec_Wec_t * vCuts, int nCuts, int nCutSizeMin )
     Vec_Wec_t * vCutsSel = Vec_WecStart( nCuts );
     int i; srand( time(NULL) );
     for ( i = 0; i < nCuts; i++ )
-        while ( !Gia_StoSelectOneCut(vCuts, (rand() | (rand() << 15)) % Vec_WecSize(vCuts), Vec_WecEntry(vCutsSel, i), nCutSizeMin) );
+        while ( !Gia_StoSelectOneCut(vCuts, (int)(((unsigned)rand() | ((unsigned)rand() << 15)) % Vec_WecSize(vCuts)), Vec_WecEntry(vCutsSel, i), nCutSizeMin) );
     return vCutsSel;
 }
 Vec_Wec_t * Gia_ManExtractCuts( Gia_Man_t * pGia, int nCutSize0, int nCuts0, int fVerbose0 )


### PR DESCRIPTION
This idiom combines two 15-bit rand() samples and is only safe when `RAND_MAX == 32767` (MSVC/Windows, [reference](https://learn.microsoft.com/en-us/cpp/c-runtime-library/rand-max?view=msvc-180)). On glibc and Apple libc, `RAND_MAX == 2147483647` ([reference](https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_node/libc_386.html)), so `rand() << 15` overflows signed `int` (UB) and
the result goes negative sometimes. The negative value is passed to `Vec_WecEntry`, tripping `assert(i >= 0)`.
