### PR TITLE
Fix(choices): On pSibls

### DIFF
--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -35100,9 +35100,9 @@ int Abc_CommandAbc9Get( Abc_Frame_t * pAbc, int argc, char ** argv )
     Aig_Man_t * pAig;
     Gia_Man_t * pGia, * pTemp;
     char * pInits;
-    int c, fGiaSimple = 0, fMapped = 0, fNames = 0, fReuseNames = 0, fVerbose = 0;
+    int c, fGiaSimple = 0, fMapped = 0, fNames = 0, fReuseNames = 0, fSibls = 0, fVerbose = 0;
     Extra_UtilGetoptReset();
-    while ( ( c = Extra_UtilGetopt( argc, argv, "cmnrvh" ) ) != EOF )
+    while ( ( c = Extra_UtilGetopt( argc, argv, "cmnrvsh" ) ) != EOF )
     {
         switch ( c )
         {
@@ -35120,6 +35120,9 @@ int Abc_CommandAbc9Get( Abc_Frame_t * pAbc, int argc, char ** argv )
             break;
         case 'v':
             fVerbose ^= 1;
+            break;
+        case 's':
+            fSibls ^= 1;
             break;
         default:
             goto usage;
@@ -35156,10 +35159,15 @@ int Abc_CommandAbc9Get( Abc_Frame_t * pAbc, int argc, char ** argv )
     else
     {
         if ( Abc_NtkGetChoiceNum(pAbc->pNtkCur) )
+        {
             pAig = Abc_NtkToDarChoices( pAbc->pNtkCur );
+            pGia = fSibls ? Gia_ManFromAigChoices( pAig ) : Gia_ManFromAig( pAig );
+        }
         else
+        {
             pAig = Abc_NtkToDar( pAbc->pNtkCur, 0, 1 );
-        pGia = Gia_ManFromAig( pAig );
+            pGia = Gia_ManFromAig( pAig );
+        }
         Aig_ManStop( pAig );
     }
     // copy names
@@ -35204,7 +35212,7 @@ int Abc_CommandAbc9Get( Abc_Frame_t * pAbc, int argc, char ** argv )
     return 0;
 
 usage:
-    Abc_Print( -2, "usage: &get [-cmnrvh] <file>\n" );
+    Abc_Print( -2, "usage: &get [-cmnrvsh] <file>\n" );
     Abc_Print( -2, "\t         converts the current network into GIA and moves it to the &-space\n" );
     Abc_Print( -2, "\t         (if the network is a sequential logic network, normalizes the flops\n" );
     Abc_Print( -2, "\t         to have const-0 initial values, equivalent to \"undc; st; zero\")\n" );
@@ -35213,6 +35221,7 @@ usage:
     Abc_Print( -2, "\t-n     : toggles saving CI/CO names of the AIG [default = %s]\n", fNames? "yes": "no" );
     Abc_Print( -2, "\t-r     : toggles reusing CI/CO names of the current AIG [default = %s]\n", fReuseNames? "yes": "no" );
     Abc_Print( -2, "\t-v     : toggles additional verbose output [default = %s]\n", fVerbose? "yes": "no" );
+    Abc_Print( -2, "\t-s     : toggles exporting choice nodes as GIA siblings (pSibls) for &if-based mapping [default = %s]\n", fSibls? "yes": "no" );
     Abc_Print( -2, "\t-h     : print the command usage\n");
     Abc_Print( -2, "\t<file> : the file name\n");
     return 1;


### PR DESCRIPTION
Fixes #528 .
Fixes #466 .

An additional parameter `-s` for `pSibls`.

## Usage showcase
It will not affect current usage, performance or structure when do `&get` and `&put`.
Eg,
```bash
./abc -c "read_aiger i10.aig; strash; dch; &get; &put; ps"   
======== ABC command line "read_aiger i10.aig; strash; dch; &get; &put; ps"
Warning: Transforming AIG with 602 choice nodes.
i10                           : i/o =  257/  224  lat =    0  and =   4206 (choice = 602)  lev = 33
./abc -c "read_aiger i10.aig; strash; dch; &get -s; &put; ps"
======== ABC command line "read_aiger i10.aig; strash; dch; &get -s; &put; ps"
Warning: Transforming AIG with 602 choice nodes.
i10                           : i/o =  257/  224  lat =    0  and =   4206 (choice = 602)  lev = 33
```

Even after the fix when use `&if` in ABC9 with choices from ABC,
```bash
./abc -c "read_aiger i10.aig; strash; dch; &get; &if -K 4; &put;"      
======== ABC command line "read_aiger i10.aig; strash; dch; &get; &if -K 4; &put;"
Assertion failed: (Gia_ObjLevel(p, pObj) > 0), function Gia_ManChoiceLevel, file giaIf.c, line 836.
[1]    84890 abort      ./abc -c "read_aiger i10.aig; strash; dch; &get; &if -K 4; &put;"
```
will still crash (since it is not correct). Use `-s` instead (trigger pSibls transformation).
```bash
./abc -c "read_aiger i10.aig; strash; dch; &get -s; &ps; &if -K 4; &ps"      
======== ABC command line "read_aiger i10.aig; strash; dch; &get -s; &ps; &if -K 4; &ps"
i10      : i/o =    257/    224  and =    4206  lev =   38 (11.36)  mem = 0.06 MB  ch =  719
cst =       0  cls =    602  lit =     719  unused =    3142  proof =     0
i10      : i/o =    257/    224  and =    2255  lev =   34 (11.54)  mem = 0.03 MB
Mapping (K=4)  :  lut =    741  edge =    2439  lev =   12 (5.70)  mem = 0.03 MB
```
Could see `ch =` printed out now.
