### PR TITLE
Fix incorrect ACB_UNUSED enum comment

### DIFF
--- a/src/base/acb/acbFunc.c
+++ b/src/base/acb/acbFunc.c
@@ -52,7 +52,7 @@ typedef enum {
     ACB_XNOR,      // 13: "xnor"
     ACB_MUX,       // 14: "_HMUX"
     ACB_DC,        // 15: "_DC"
-    ACB_UNUSED     // 14: unused
+    ACB_UNUSED     // 16: unused
 } Acb_KeyWords_t; 
 
 static inline char * Acb_Num2Name( int i )


### PR DESCRIPTION
Fixes an incorrect comment in the Acb_KeyWords_t enum.

ACB_UNUSED follows ACB_DC, whose value is 15, so ACB_UNUSED is automatically assigned value 16. The previous comment incorrectly stated that it was 14.