### PR TITLE
Fix eSLIM crashes from non-contiguous delay selectors and unstrashed Gia export.

### DIFF
--- a/src/opt/eslim/delayEngine.cpp
+++ b/src/opt/eslim/delayEngine.cpp
@@ -121,9 +121,17 @@ namespace eSLIM {
   }
   
   std::vector<bool> DelayEngine::reduceDelay(unsigned int max_size, unsigned int initial_delay) {
-    assert (delay_selectors.find(initial_delay) != delay_selectors.end());
+    // delay_selectors keys are arrival+remaining+d and need not be contiguous.
+    // Callers may pass a value that falls in a gap (e.g. replacement_delay-1 after
+    // area minimization). Use lower_bound (map is ordered by std::greater) to start
+    // from the largest representable delay <= initial_delay instead of requiring an
+    // exact key, which previously asserted and aborted.
     std::vector<bool> last_model;
-    for( auto it = delay_selectors.find(initial_delay); it != delay_selectors.end(); ++it ) {
+    auto it = delay_selectors.lower_bound(initial_delay);
+    if (it == delay_selectors.end()) {
+      return last_model;
+    }
+    for (; it != delay_selectors.end(); ++it ) {
       int d = it->first;
       double timeout = getDynamicTimeout(max_size);
       int status = existsReplacement(max_size, d, timeout);

--- a/src/opt/eslim/eslimCirMan.cpp
+++ b/src/opt/eslim/eslimCirMan.cpp
@@ -564,7 +564,13 @@ namespace eSLIM {
       node_ids[i] = id;
     }
 
-    return pNew;
+    // Rehash before returning: without structural hashing, ANDs that become trivial
+    // under hashing (e.g. AND(x,!x)->const) remain as unreachable nodes after
+    // Gia_ManToAig, which causes Aig_ManDupDfs / Aig_ManDfs to assert during
+    // inprocessing (DeepSyn / &dch).
+    Gia_Man_t * pStrash = Gia_ManRehash( pNew, 0 );
+    Gia_ManStop( pNew );
+    return pStrash;
   }
 
   Abc_Ntk_t* eSLIMCirMan::eSLIMCirManToNtk() {


### PR DESCRIPTION
- Fix &eslim -D 2 abort in DelayEngine::reduceDelay: delay-selector keys (arrival + remaining + d) are not contiguous, so callers such as AreaDelayMinimizer (replacement_delay - 1) can request a value that is not present in delay_selectors. Replaced the exact find() assert with lower_bound (map ordered by std::greater) so iteration starts at the largest representable delay ≤ initial_delay.

- Fix &eslim -D 0 / -D 3 aborts in Aig_ManDupDfs / Aig_ManDfs during inprocessing: eSLIMCirManToGia() returned an unstrashed Gia. After Gia_ManToAig, ANDs that hash to constants/existing nodes become unreachable from COs, violating DFS node-count assumptions used by DeepSyn/&dch. Rehash with Gia_ManRehash before returning the Gia.