### PR TITLE
fraig_store: restore the PI order when the name comparison fails

### DIFF
--- a/src/base/abci/abcFraig.c
+++ b/src/base/abci/abcFraig.c
@@ -670,13 +670,29 @@ int Abc_NtkFraigStore( Abc_Ntk_t * pNtkAdd )
         extern int Abc_NodeCompareCiCo( Abc_Ntk_t * pNtkOld, Abc_Ntk_t * pNtkNew );
         if ( !Abc_NodeCompareCiCo(pNtk, (Abc_Ntk_t *)Vec_PtrEntry(vStore, 0)) )
         {
+            // Abc_NtkCompareSignals() sorts the PIs/POs/boxes of both networks by name as a
+            // side effect, which is what makes the comparison meaningful when the two do use
+            // the same names.  When they do not, the comparison fails, the store is reset and
+            // this network is kept -- so the sort has to be undone here.  Otherwise the stored
+            // network is a permutation of the one the caller read in, and everything after it
+            // is off by that permutation with nothing to indicate it.
+            Vec_Ptr_t * vPis   = Vec_PtrDup( pNtk->vPis );
+            Vec_Ptr_t * vPos   = Vec_PtrDup( pNtk->vPos );
+            Vec_Ptr_t * vBoxes = Vec_PtrDup( pNtk->vBoxes );
             // reorder PIs of pNtk2 according to pNtk1
             if ( !Abc_NtkCompareSignals( pNtk, (Abc_Ntk_t *)Vec_PtrEntry(vStore, 0), 1, 1 ) )
             {
+                Vec_PtrFree( pNtk->vPis );   pNtk->vPis   = vPis;   vPis   = NULL;
+                Vec_PtrFree( pNtk->vPos );   pNtk->vPos   = vPos;   vPos   = NULL;
+                Vec_PtrFree( pNtk->vBoxes ); pNtk->vBoxes = vBoxes; vBoxes = NULL;
+                Abc_NtkOrderCisCos( pNtk );
                 printf( "Trying to store the network with different primary inputs.\n" );
                 printf( "The previously stored networks are deleted and this one is added.\n" );
                 Abc_NtkFraigStoreClean();
             }
+            if ( vPis )   Vec_PtrFree( vPis );
+            if ( vPos )   Vec_PtrFree( vPos );
+            if ( vBoxes ) Vec_PtrFree( vBoxes );
         }
     }
     Vec_PtrPush( vStore, pNtk );


### PR DESCRIPTION
Follow-up to #537, which I filed before I had the mechanism right. It is not PI *invention* in `Abc_NtkAppendToCone()` — that branch is never reached here. It is PI *reordering*, one level up, and it has a two-line fix.

### What happens

`Abc_NtkCompareSignals()` calls `Abc_NtkOrderObjsByName()` on both networks, which `qsort`s `vPis`, `vPos` and `vBoxes` in place before the comparison. That is deliberate: it is what lets `fraig_store` accept two networks that use the same port names in a different order.

When the names genuinely differ, the comparison fails and `Abc_NtkFraigStore()` takes this path:

```c
if ( !Abc_NtkCompareSignals( pNtk, (Abc_Ntk_t *)Vec_PtrEntry(vStore, 0), 1, 1 ) )
{
    printf( "Trying to store the network with different primary inputs.\n" );
    printf( "The previously stored networks are deleted and this one is added.\n" );
    Abc_NtkFraigStoreClean();
}
Vec_PtrPush( vStore, pNtk );
```

The store is reset and `pNtk` is kept — but `pNtk` has already been sorted by the comparison that failed. What goes into the store is a permutation of the network the caller read in. The two printed lines say the store was reset; nothing says the interface changed.

Sorting is by name as a string, so numeric port names are the worst case: `1, 2, …, 10` sorts to `1, 10, 2, 3, …`.

### Reproducing

EPFL `cavlc` and its published reference netlist, whose ports are named `1`…`10`:

```
read_aiger cavlc.aig;        strash; fraig_store
read_blif  cavlc_size.blif;  strash; fraig_store
fraig_restore; write_blif out.blif
```

```
$ abc -q "read_blif out.blif; print_io"
Primary inputs (10):  0=1 1=10 2=2 3=3 4=4 5=5 6=6 7=7 8=8 9=9
                            ^^^^ should be 1=2

$ abc -q "cec -n out.blif cavlc.aig"
Output po00: Value in Network1 = 0. Value in Network2 = 1.
```

Right number of inputs and outputs, passes `Abc_NtkCheck()`, wrong function. The reference netlist on its own is equivalent — only going through `fraig_store` breaks it, and only because the store then discards it and keeps the sorted copy.

I ran into this building choice networks out of differently-named implementations of the same circuit; 9 of 20 merges came back non-equivalent with plausible-looking area and depth. The workaround is to round-trip everything through `write_aiger`/`read_aiger` first so names are regenerated positionally, but the sort surviving a failed comparison seemed worth fixing rather than working around.

### The change

Save `vPis`/`vPos`/`vBoxes` before the comparison, put them back if it fails, and rebuild `vCis`/`vCos` with `Abc_NtkOrderCisCos()`.

Deliberately narrow:

- The **success** path is untouched — when the names do line up, both networks stay sorted into the common order, which is the point.
- Networks whose names already agree never reach `Abc_NtkCompareSignals()` at all, because `Abc_NodeCompareCiCo()` has already returned 1.
- The warning still prints, and the store is still reset.

### Checks

Built clean. Against the EPFL suite:

- `cavlc` with the mismatched reference: PI order now `0=1 1=2 2=3 …`, and `cec -n` reports equivalent.
- `ctrl`, `arbiter`, `max` — names already agree — merge and verify exactly as before.
- Same-interface merge, and a plain single-network `fraig_store`/`fraig_restore`, both unchanged.
- The warning is still emitted on the mismatch path.

Happy to add the name-mismatch case to a regression test if you have a preferred place for it.
