### PR TITLE
acd: uninitialised read of bestPerm in enumerate_iset_combinations

### DIFF
--- a/src/map/if/acd/ac_decomposition.hpp
+++ b/src/map/if/acd/ac_decomposition.hpp
@@ -482,6 +482,11 @@ private:
     for ( uint32_t i = 0; i < num_vars; ++i )
     {
       pComb[i] = pInvPerm[i] = i;
+      /* bestPerm is written only when some combination beats the initial
+       * best_cost.  When none does, the loop below still evaluates
+       * permutations[bestPerm[i]], which reads uninitialised stack and then
+       * indexes permutations[] with it.  Seed the identity permutation. */
+      bestPerm[i] = i;
     }
 
     /* early bail-out conditions */


### PR DESCRIPTION
### The defect

In `src/map/if/acd/ac_decomposition.hpp`, `enumerate_iset_combinations` declares

```cpp
uint32_t pComb[16], pInvPerm[16], bestPerm[16];
```

and writes `bestPerm` **only** inside the `cost < best_cost` branch:

```cpp
if ( cost < best_cost )
{
  ...
  for ( uint32_t i = 0; i < num_vars; ++i )
    bestPerm[i] = pComb[i];
  ...
}
```

When no combination beats the initial `best_cost` — which happens for an infeasible free-set size — `bestPerm` is never written. The tail of the function nevertheless evaluates it:

```cpp
for ( uint32_t i = 0; i < num_vars; ++i )
  res_perm[i] = permutations[bestPerm[i]];
```

That is a read of uninitialised stack, and because the value is then used as an index into `permutations[]`, it is an out-of-bounds read as well.

### Impact

Benign in upstream today: the caller discards that permutation on the infeasible path, so results are unaffected. But it is undefined behaviour, and it becomes a reliable segfault the moment the stack layout shifts — adding two members to the decomposer object was enough to reproduce it consistently while instrumenting the pass.

### The fix

Seed the identity permutation in the initialisation loop that already runs immediately above. Five lines, no behavioural change on any path that was previously well-defined, and no measurable cost.

### Testing

Built clean, and `if -K 10 -Z 6` still maps correctly (`cavlc`: `nd = 121, lev = 4`). Found while measuring ACD's column-multiplicity headroom across the EPFL suite; the pass was exercised over 180+ mapping jobs on this branch with no change in output.