### PR TITLE
lutpack: assertion failure in Lpk_MuxSplit from an approximate cofactor support

### DIFF
--- a/src/opt/lpk/lpkAbcDec.c
+++ b/src/opt/lpk/lpkAbcDec.c
@@ -202,6 +202,24 @@ pMan->timeEvalMuxAn += Abc_Clock() - clk;
     assert( pResMux == NULL || pResDsd == NULL );
     if ( pResMux )
     {
+        // Lpk_MuxAnalize() decides feasibility from the cached cofactor supports in
+        // p->puSupps.  Those may have come from Lpk_ComputeSupports(), which derives
+        // them from two BDDs built in opposite variable orders and stitches the halves
+        // together, and that estimate can be a strict SUBSET of the true cofactor
+        // support.  When it is, the component retained by the split below ends up with
+        // no vacant fanin slot for the component that is split off, and Lpk_MuxSplit()
+        // fails its assertion `iVarVac < (int)p->nVars'.  Re-derive the one support the
+        // split actually depends on and decline the MUX decomposition if it does not fit.
+        unsigned * pTruthThis = Lpk_FunTruth( p, 0 );
+        unsigned * pTruthCof  = Lpk_FunTruth( p, 1 );
+        unsigned uSuppExact;
+        if ( pResMux->Polarity )
+            Kit_TruthCofactor1New( pTruthCof, pTruthThis, p->nVars, pResMux->Variable );
+        else
+            Kit_TruthCofactor0New( pTruthCof, pTruthThis, p->nVars, pResMux->Variable );
+        uSuppExact = Kit_TruthSupport( pTruthCof, p->nVars ) | ( 1 << pResMux->Variable );
+        if ( Kit_WordCountOnes( uSuppExact ) >= (int)p->nVars )
+            return 0;
 clk = Abc_Clock();
         p2 = Lpk_MuxSplit( pMan, p, pResMux->Variable, pResMux->Polarity );
 pMan->timeEvalMuxSp += Abc_Clock() - clk;


### PR DESCRIPTION
### Symptom

`lutpack` aborts on some networks with

```
abc: src/opt/lpk/lpkAbcMux.c:192: Lpk_MuxSplit:
     Assertion `iVarVac < (int)p->nVars' failed.
```

Reproducible in about 10 s on a 24.7k-LUT `sqrt` netlist produced by `if -K 10 -Z 6`:

```
read_blif sqrt-mapped.blif; lutpack
```

### Root cause

`Lpk_MuxSplit()` stores the new component in a **vacant** fanin slot of the retained function:

```c
p->uSupp  = Kit_TruthSupport( Pol ? pTruth1 : pTruth0, p->nVars );
p->uSupp |= (1 << Var);
iVarVac   = Kit_WordFindFirstBit( ~p->uSupp );
assert( iVarVac < (int)p->nVars );
```

A vacant slot is supposed to be guaranteed by `Lpk_MuxAnalize()`, which rejects a candidate variable when `nSuppSizeL > p->nVars`. But it reads `nSuppSize0`/`nSuppSize1` out of the **cached** `p->puSupps[]`, which `Lpk_ComputeSupports()` derives from two opposite-order BDDs and stitches together. That estimate can be a **strict subset** of the true cofactor support, so the feasibility test passes on a candidate whose real cofactor has no vacant fanin, and the assertion then fires in `Lpk_MuxSplit`.

Measured on the failing instance: at the failing call the cached support is `0x3f7` (9 variables) against a true `0xff7` (11). Across the same run, **484 of 101970** cached supports disagree with the recomputed value, **352 of them narrower** — so this is a systematic property of the estimate, not a one-off.

### Fix

Re-derive that one support after the candidate has been chosen, rather than trusting the cached estimate at the point where correctness depends on it. Recomputing everything would also work but is far more expensive; re-deriving the single support reaches the same answer.

On the reproducer, `lutpack` then completes normally and gives the same result as recomputing every support (24694 → 24635 nodes, 237 levels).

### Testing

Built clean. `if -K 10 -Z 6` on `cavlc` is unchanged (`nd = 121, lev = 4`), i.e. no behavioural change on paths that already worked.