### PR TITLE
ACD: 64-bit shift by 64 or more in local_extend_to

### DIFF
--- a/src/map/if/acd/ac_decomposition.hpp
+++ b/src/map/if/acd/ac_decomposition.hpp
@@ -1317,7 +1317,10 @@ private:
     {
       auto mask = *tt.begin();
 
-      for ( auto i = real_num_vars; i < num_vars; ++i )
+      /* Replicate within the word only.  Variables 6 and above are replicated by the
+       * std::fill below, and shifting a 64-bit word by (1 << i) for i >= 6 is undefined
+       * behaviour rather than a no-op. */
+      for ( auto i = real_num_vars; i < std::min( num_vars, 6u ); ++i )
       {
         mask |= ( mask << ( 1 << i ) );
       }


### PR DESCRIPTION
### The defect

In `src/map/if/acd/ac_decomposition.hpp`, `local_extend_to` replicates a truth-table word:

```cpp
auto mask = *tt.begin();

for ( auto i = real_num_vars; i < num_vars; ++i )
{
  mask |= ( mask << ( 1 << i ) );
}
```

`mask` is a 64-bit word, so for `i >= 6` the shift amount `1 << i` is at least 64. Shifting a 64-bit integer by 64 or more is **undefined behaviour** in C++, not a no-op — in practice x86 masks the count to 6 bits, so `mask << 64` becomes `mask << 0` and the value silently doubles instead of being left alone.

Variables 6 and above are already replicated by the `std::fill` that follows, so the loop only ever needs to cover the within-word variables.

### Reach

This is hit on **every** `if -K k -Z n` invocation with `k > 6`, i.e. on every use of the delay-driven ACD path with cuts wider than a word. Found with UBSan.

### Fix

Bound the loop at 6, with a comment recording why the tail is unnecessary rather than merely harmless.

### Testing

Built clean. `if -K 10 -Z 6` on `cavlc` is unchanged (`nd = 121, lev = 4`).

Related: #539 (uninitialised `bestPerm` read in the same file) and #540 (`lutpack` assertion), both found while measuring this decomposer across the EPFL suite.