### PR TITLE
Fix &b crash with input arrivals after save

### DIFF
--- a/src/aig/gia/giaBalAig.c
+++ b/src/aig/gia/giaBalAig.c
@@ -1060,6 +1060,8 @@ Gia_Man_t * Gia_ManAreaBalance( Gia_Man_t * p, int fSimpleAnd, int nNewNodesMax,
     else if ( p->vInArrs )
     {
         int i, Id, And2Delay = p->And2Delay ? p->And2Delay : 1;
+        Vec_IntFreeP( &p->vLevels );
+        p->vLevels = Vec_IntStart( Gia_ManObjNum(p) );
         Gia_ManForEachCiId( p, Id, i )
             Vec_IntWriteEntry( p->vLevels, Id, (int)(Vec_FltEntry(p->vInArrs, i)/And2Delay) );
     }


### PR DESCRIPTION
Fix a segfault in `&b` after `save`.

`save` evaluates mapped delay and initializes the network timing manager.
After `strash`, `&get -nm` transfers this timing information into `Gia_Man_t::vInArrs`. `Gia_ManAreaBalance()` then writes CI levels through `p->vLevels`, but the `vInArrs` branch did not allocate this vector.

Minimal reproducer:

```abc
read <library>
read_lib <library>
read i10.aig
strash
map; save; strash
&get -nm; &b
```

Without `save`, the sequence completes. Before this fix, the sequence with
save segfaults at `src/aig/gia/giaBalAig.c:1064`.