### PR TITLE
Make Aig_And commutative when fAddStrash is enabled.

### DIFF
--- a/src/aig/aig/aigOper.c
+++ b/src/aig/aig/aigOper.c
@@ -118,6 +118,8 @@ Aig_Obj_t * Aig_And( Aig_Man_t * p, Aig_Obj_t * p0, Aig_Obj_t * p1 )
     if ( p->fAddStrash && (Aig_ObjIsNode(Aig_Regular(p0)) || Aig_ObjIsNode(Aig_Regular(p1))) )
     { // http://fmv.jku.at/papers/BrummayerBiere-MEMICS06.pdf
         Aig_Obj_t * pFanA, * pFanB, * pFanC, * pFanD;
+        if ( Aig_Regular(p0)->Id > Aig_Regular(p1)->Id )
+            ABC_SWAP( Aig_Obj_t *, p0, p1 );
         pFanA = Aig_ObjChild0(Aig_Regular(p0));
         pFanB = Aig_ObjChild1(Aig_Regular(p0));
         pFanC = Aig_ObjChild0(Aig_Regular(p1));


### PR DESCRIPTION
ANDs' operands are ordered by regular id, but if `fAddStrash` is enabled, after `p0`'s children are compared against `p1`'s .

A different node can be a produced when `p0` and `p1` are swapped. That is `Aig_And(p0, p1)` does not necessarily produce the same result as `Aig_And(p1, p0)`.

This patch makes `Aig_And` commutative when `fAddStresh` is enabled.


