### PR TITLE
lutpack: warn when the installed LUT library is narrower than the network

### DIFF
--- a/src/opt/lpk/lpkCore.c
+++ b/src/opt/lpk/lpkCore.c
@@ -604,6 +604,13 @@ int Lpk_Resynthesize( Abc_Ntk_t * pNtk, Lpk_Par_t * pPars )
         pPars->nLutSize = 6;
     if ( pPars->nLutSize < 3 )
         pPars->nLutSize = 3;
+    // If_Init() installs a 4-input LUT library at start-up, and it is always present,
+    // so the branch above always takes the library width and never the max fanin count
+    // that the "lutpack" usage message advertises.  Packing a 6-LUT network for 4-LUTs
+    // is close to inert, and silently so; say something when the widths disagree.
+    if ( Abc_FrameReadLibLut() && pPars->nLutSize < Abc_NtkGetFaninMax(pNtk) )
+        Abc_Print( ABC_WARNING, "Packing for %d-LUTs because the installed LUT library is %d-input, while the network has nodes with up to %d fanins. Use \"read_lut\" to install a wider library.\n",
+            pPars->nLutSize, ((If_LibLut_t *)Abc_FrameReadLibLut())->LutMax, Abc_NtkGetFaninMax(pNtk) );
     // adjust the number of crossbars based on LUT size
     if ( pPars->nVarsShared > pPars->nLutSize - 2 )
         pPars->nVarsShared = pPars->nLutSize - 2;


### PR DESCRIPTION
`lutpack`'s own usage text says it "determines LUT size as the max fanin count of a node", but `Lpk_Resynthesize` only does that in the `else` branch, when no LUT library is installed, and `If_Init()` installs a 4-input library at start-up and nothing removes it — so in a normal session the fallback is unreachable and plain `lutpack` always packs for 4 inputs, which on a 6-LUT netlist is close to a no-op. On EPFL `mem_ctrl` mapped with `strash; if -K 6`, `lutpack` alone goes 12104 -> 12069 nodes, while the same command after `read_lut` of a 6-input library goes 12104 -> 11494; across 31 benchmarks the stock default changed the LUT count on 2 of 31 fresh mappings, against 15 of 31 and geomean -2.39% (Wilcoxon p = 6.2e-4) when the width is set to 6, and it regressed neither LUT count nor levels anywhere. So the question is whether the 4-input default is intended — plausibly it is, as a legacy of the 4-LUT era, in which case the usage text is what is out of date. This patch is the smallest thing we could think of that makes the mismatch visible: one warning when the installed library is narrower than the network's max fanin count, no change to any result. The alternative we considered and did not propose is defaulting the width to the network's max fanin count, which is what the usage text already promises but would change everybody's numbers; if you would rather have that, or a line in the help text instead, we are happy to redo it. This is orthogonal to #542 — that one is about `lutpack` producing a non-equivalent netlist, and this change only prints.
