### PR TITLE
Use memset for 0 and -1 fills in Vec_IntFillExtra

### DIFF
--- a/src/misc/vec/vecInt.h
+++ b/src/misc/vec/vecInt.h
@@ -635,8 +635,11 @@ static inline void Vec_IntFillExtra( Vec_Int_t * p, int nSize, int Fill )
         Vec_IntGrow( p, nSize );
     else if ( nSize > p->nCap )
         Vec_IntGrow( p, p->nCap < ABC_INT_MAX/2 ? 2 * p->nCap : ABC_INT_MAX );
-    for ( i = p->nSize; i < nSize; i++ )
-        p->pArray[i] = Fill;
+    if ( Fill == 0 || Fill == -1 )
+        memset( p->pArray + p->nSize, Fill, sizeof(int) * (size_t)(nSize - p->nSize) );
+    else
+        for ( i = p->nSize; i < nSize; i++ )
+            p->pArray[i] = Fill;
     p->nSize = nSize;
 }
 


### PR DESCRIPTION
This change causes Aig_ManUpdateReverseLevel to drop from 21.01% down to 19.49% of total execution time (-1.52% overall runtime reduction).