### PR TITLE
Avoid pointer chasing for pFanout->Id when we already have it in `Aig_ManUpdateReverseLevel`

### DIFF
--- a/src/aig/aig/aig.h
+++ b/src/aig/aig/aig.h
@@ -428,6 +428,10 @@ static inline int     Aig_ObjFanoutNext( Aig_Man_t * p, int iFan )   { assert(iF
     for ( assert(p->pFanData), i = 0; (i < (int)(pObj)->nRefs) &&               \
           (((iFan) = i? Aig_ObjFanoutNext(p, iFan) : Aig_ObjFanout0Int(p, pObj->Id)), 1) && \
           (((pFanout) = Aig_ManObj(p, iFan>>1)), 1); i++ )
+#define Aig_ObjForEachFanoutId( p, pObj, FanId, iFan, i )                       \
+    for ( assert(p->pFanData), i = 0; (i < (int)(pObj)->nRefs) &&               \
+          (((iFan) = i? Aig_ObjFanoutNext(p, iFan) : Aig_ObjFanout0Int(p, pObj->Id)), 1) && \
+          (((FanId) = (iFan >> 1)), 1); i++ )
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/aig/aig/aigTiming.c
+++ b/src/aig/aig/aigTiming.c
@@ -116,11 +116,10 @@ int Aig_ObjRequiredLevel( Aig_Man_t * p, Aig_Obj_t * pObj )
 ***********************************************************************/
 int Aig_ObjReverseLevelNew( Aig_Man_t * p, Aig_Obj_t * pObj )
 {
-    Aig_Obj_t * pFanout;
-    int i, iFanout = -1, LevelCur, Level = 0;
-    Aig_ObjForEachFanout( p, pObj, pFanout, iFanout, i )
+    int i, iFanout = -1, FanoutId, LevelCur, Level = 0;
+    Aig_ObjForEachFanoutId( p, pObj, FanoutId, iFanout, i )
     {
-        LevelCur = Aig_ObjReverseLevel( p, pFanout );
+        LevelCur = Vec_IntGetEntry( p->vLevelR, FanoutId );
         Level = Abc_MaxInt( Level, LevelCur );
     }
     return Level + 1;
@@ -250,6 +249,8 @@ void Aig_ManUpdateReverseLevel( Aig_Man_t * p, Aig_Obj_t * pObjNew )
     int LevelOld, LevFanin, Lev, k;
     assert( p->vLevelR != NULL );
     assert( Aig_ObjIsNode(pObjNew) );
+    // ensure reverse levels array is large enough for all objects
+    Vec_IntFillExtra( p->vLevelR, Aig_ManObjNumMax(p), 0 );
     // allocate level if needed
     if ( p->vLevels == NULL )
         p->vLevels = Vec_VecAlloc( Aig_ManLevels(p) + 8 );


### PR DESCRIPTION
The diff makes it hard to see, but doing some manual inlining shows the changes we are trying to make look like:
Before:
```c++
    pFanout = p->vObjs->pArray[iFanout >> 1];
    int FanoutId = pFanout->Id;
    Vec_IntFillExtra( p->vLevelR, FanoutId + 1, 0 );
    LevelCur = p->vLevelR->pArray[FanoutId];
```
After:
```c++
    int FanoutId = iFanout >> 1;
    Vec_IntFillExtra( p->vLevelR, FanoutId + 1, 0 );
    LevelCur = p->vLevelR->pArray[FanoutId];
```
By using `Vec_IntGetEntry(p->vLevelR, FanoutId)` directly, the memory loads to retrieve `pFanout` and dereference `pFanout->Id` are completely eliminated.
  
The `Vec_IntFillExtra( p->vLevelR, Aig_ManObjNumMax(p), 0 );` seeks to avoid any resizing in the loop.  
  
This can speed up `Aig_ManUpdateReverseLevel` about 40% in our tests, our profiling showed a large amount of time spent waiting on the pFanout data to fetch from memory.

There is an assumption that `  int FanoutId = iFanout >> 1;` will remain valid in the future, but who ever is reviewing hopefully can comment on that.

