### PR TITLE
Introduce Abc_GetTmpDir() to set the tmp directory via $TMPDIR

### DIFF
--- a/src/aig/gia/giaStoch.c
+++ b/src/aig/gia/giaStoch.c
@@ -115,8 +115,8 @@ Vec_Int_t * Gia_StochProcessArray( Vec_Ptr_t * vGias, char * pScript, int TimeSe
 Gia_Man_t * Gia_StochProcessOne( Gia_Man_t * p, char * pScript, int Rand, int TimeSecs )
 {
     Gia_Man_t * pNew;
-    char FileName[100], Command[1000];
-    sprintf( FileName, "%06x.aig", Rand );
+    char FileName[1000], Command[2000];
+    sprintf( FileName, "%s/%06x.aig", Abc_GetTmpDir(), Rand );
     Gia_AigerWrite( p, FileName, 0, 0, 0 );
     sprintf( Command, "./abc -q \"&read %s; %s; &write %s\"", FileName, pScript, FileName );
 #if defined(__wasm)

--- a/src/base/abci/abcPart.c
+++ b/src/base/abci/abcPart.c
@@ -1296,10 +1296,10 @@ Abc_Ntk_t * Abc_NtkStochProcessOne( Abc_Ntk_t * p, char * pScript0, int Rand, in
     extern int Abc_NtkWriteToFile( char * pFileName, Abc_Ntk_t * pNtk );
     extern Abc_Ntk_t * Abc_NtkReadFromFile( char * pFileName );
     Abc_Ntk_t * pNew, * pTemp;
-    char FileName[100], Command[1000], PreCommand[500] = {0};
+    char FileName[1000], Command[2000], PreCommand[500] = {0};
     char * pLibFileName = Abc_NtkIsMappedLogic(p) ? Mio_LibraryReadFileName((Mio_Library_t *)p->pManFunc) : NULL;
     if ( pLibFileName ) sprintf( PreCommand, "read_genlib %s; ", pLibFileName );
-    sprintf( FileName, "%06x.mm", Rand );
+    sprintf( FileName, "%s/%06x.mm", Abc_GetTmpDir(), Rand );
     Abc_NtkWriteToFile( FileName, p );    
     char * pScript = Abc_UtilStrsav( pScript0 );
     sprintf( Command, "./abc -q \"%sread_mm %s; %s; write_mm %s\"", PreCommand[0] ? PreCommand : "", FileName, pScript, FileName );    

--- a/src/base/sn/snCom.c
+++ b/src/base/sn/snCom.c
@@ -96,12 +96,9 @@ static int Sn_TempPrefix( char * pBuffer, size_t nBuffer, const char * pStem )
 {
     int Written;
 #if defined(_MSC_VER) || defined(__MINGW32__)
-    const char * pDirectory = getenv( "TEMP" );
-    if ( pDirectory == NULL )
-        pDirectory = ".";
-    Written = snprintf( pBuffer, nBuffer, "%s\\%s", pDirectory, pStem );
+    Written = snprintf( pBuffer, nBuffer, "%s\\%s", Abc_GetTmpDir(), pStem );
 #else
-    Written = snprintf( pBuffer, nBuffer, "/tmp/%s", pStem );
+    Written = snprintf( pBuffer, nBuffer, "%s/%s", Abc_GetTmpDir(), pStem );
 #endif
     return Written >= 0 && (size_t)Written < nBuffer;
 }

--- a/src/misc/util/abc_global.h
+++ b/src/misc/util/abc_global.h
@@ -590,6 +590,25 @@ static inline void Abc_ReverseOrder( int * pA, int nA )
         ABC_SWAP( int, pA[i], pA[nA-1-i] );
 }
 
+static inline const char * Abc_GetTmpDir()
+{
+    const char * s;
+#if defined(_MSC_VER) || defined(__MINGW32__)
+    s = getenv( "TMP" );
+    if ( s && *s )
+        return s;
+    s = getenv( "TEMP" );
+    if ( s && *s )
+        return s;
+    return ".";
+#else
+    s = getenv( "TMPDIR" );
+    if ( s && *s )
+        return s;
+    return "/tmp";
+#endif
+}
+
 
 // sorting
 extern void   Abc_MergeSort( int * pInput, int nSize );

--- a/src/misc/util/utilAigSim.c
+++ b/src/misc/util/utilAigSim.c
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <time.h>
+#include "abc_global.h"
 #ifdef _WIN32
 #include <io.h>
 #define mkstemp(p) _mktemp_s(p, strlen(p)+1)
@@ -345,8 +346,11 @@ static int make_tmp_file(char *path, size_t cap, const char *prefix) {
     static int seq = 0; // no risk of collision since we're in a sandbox
     snprintf(path, cap, "%s%08d", prefix, seq++);
     int fd = open(path, O_CREAT | O_EXCL | O_RDWR, S_IREAD | S_IWRITE);
+#elif defined(_WIN32)
+    snprintf(path, cap, "%s\\%sXXXXXX", Abc_GetTmpDir(), prefix);
+    int fd = mkstemp(path);
 #else
-    snprintf(path, cap, "/tmp/%sXXXXXX", prefix);
+    snprintf(path, cap, "%s/%sXXXXXX", Abc_GetTmpDir(), prefix);
     int fd = mkstemp(path);
 #endif
     if (fd < 0) return 0;
@@ -360,8 +364,11 @@ static int make_tmp_path_noexist(char *path, size_t cap, const char *prefix) {
     static int seq = 0; // no risk of collision since we're in a sandbox
     snprintf(path, cap, "%s%08d", prefix, seq++);
     int fd = open(path, O_CREAT | O_EXCL | O_RDWR, S_IREAD | S_IWRITE);
+#elif defined(_WIN32)
+    snprintf(path, cap, "%s\\%sXXXXXX", Abc_GetTmpDir(), prefix);
+    int fd = mkstemp(path);
 #else
-    snprintf(path, cap, "/tmp/%sXXXXXX", prefix);
+    snprintf(path, cap, "%s/%sXXXXXX", Abc_GetTmpDir(), prefix);
     int fd = mkstemp(path);
 #endif
     if (fd < 0) return 0;

--- a/src/misc/util/utilFile.c
+++ b/src/misc/util/utilFile.c
@@ -107,9 +107,14 @@ int tmpFile(const char* prefix, const char* suffix, char** out_name)
 {
 #if defined(_MSC_VER) || defined(__MINGW32__)
     int i, fd;
-    *out_name = (char*)malloc(strlen(prefix) + strlen(suffix) + 27);
+    const char* dir = (strchr(prefix, '/') == NULL && strchr(prefix, '\\') == NULL) ? Abc_GetTmpDir() : "";
+    int need_slash = (*dir != '\0' && dir[strlen(dir)-1] != '\\' && dir[strlen(dir)-1] != '/');
+    *out_name = (char*)malloc(strlen(dir) + need_slash + strlen(prefix) + strlen(suffix) + 27);
     for (i = 0; i < 10; i++){
-        sprintf(*out_name, "%s%I64X%d%s", prefix, realTimeAbs(), _getpid(), suffix);
+        if (*dir != '\0')
+            sprintf(*out_name, "%s%s%s%I64X%d%s", dir, need_slash ? "\\" : "", prefix, realTimeAbs(), _getpid(), suffix);
+        else
+            sprintf(*out_name, "%s%I64X%d%s", prefix, realTimeAbs(), _getpid(), suffix);
         fd = _open(*out_name, O_CREAT | O_EXCL | O_BINARY | O_RDWR, _S_IREAD | _S_IWRITE);
         if (fd == -1){
             free(*out_name);
@@ -132,9 +137,14 @@ int tmpFile(const char* prefix, const char* suffix, char** out_name)
     return fd;
 #else
     int fd;
-    *out_name = (char*)malloc(strlen(prefix) + strlen(suffix) + 7);
+    const char* dir = (strchr(prefix, '/') == NULL) ? Abc_GetTmpDir() : "";
+    int need_slash = (*dir != '\0' && dir[strlen(dir)-1] != '/');
+    *out_name = (char*)malloc(strlen(dir) + need_slash + strlen(prefix) + strlen(suffix) + 7);
     assert(*out_name != NULL);
-    sprintf(*out_name, "%sXXXXXX", prefix);
+    if (*dir != '\0')
+        sprintf(*out_name, "%s%s%sXXXXXX", dir, need_slash ? "/" : "", prefix);
+    else
+        sprintf(*out_name, "%sXXXXXX", prefix);
     fd = mkstemp(*out_name);
     if (fd == -1){
         free(*out_name);

--- a/src/misc/util/utilFile.c
+++ b/src/misc/util/utilFile.c
@@ -107,14 +107,9 @@ int tmpFile(const char* prefix, const char* suffix, char** out_name)
 {
 #if defined(_MSC_VER) || defined(__MINGW32__)
     int i, fd;
-    const char* dir = (strchr(prefix, '/') == NULL && strchr(prefix, '\\') == NULL) ? Abc_GetTmpDir() : "";
-    int need_slash = (*dir != '\0' && dir[strlen(dir)-1] != '\\' && dir[strlen(dir)-1] != '/');
-    *out_name = (char*)malloc(strlen(dir) + need_slash + strlen(prefix) + strlen(suffix) + 27);
+    *out_name = (char*)malloc(strlen(prefix) + strlen(suffix) + 27);
     for (i = 0; i < 10; i++){
-        if (*dir != '\0')
-            sprintf(*out_name, "%s%s%s%I64X%d%s", dir, need_slash ? "\\" : "", prefix, realTimeAbs(), _getpid(), suffix);
-        else
-            sprintf(*out_name, "%s%I64X%d%s", prefix, realTimeAbs(), _getpid(), suffix);
+        sprintf(*out_name, "%s%I64X%d%s", prefix, realTimeAbs(), _getpid(), suffix);
         fd = _open(*out_name, O_CREAT | O_EXCL | O_BINARY | O_RDWR, _S_IREAD | _S_IWRITE);
         if (fd == -1){
             free(*out_name);
@@ -137,14 +132,9 @@ int tmpFile(const char* prefix, const char* suffix, char** out_name)
     return fd;
 #else
     int fd;
-    const char* dir = (strchr(prefix, '/') == NULL) ? Abc_GetTmpDir() : "";
-    int need_slash = (*dir != '\0' && dir[strlen(dir)-1] != '/');
-    *out_name = (char*)malloc(strlen(dir) + need_slash + strlen(prefix) + strlen(suffix) + 7);
+    *out_name = (char*)malloc(strlen(prefix) + strlen(suffix) + 7);
     assert(*out_name != NULL);
-    if (*dir != '\0')
-        sprintf(*out_name, "%s%s%sXXXXXX", dir, need_slash ? "/" : "", prefix);
-    else
-        sprintf(*out_name, "%sXXXXXX", prefix);
+    sprintf(*out_name, "%sXXXXXX", prefix);
     fd = mkstemp(*out_name);
     if (fd == -1){
         free(*out_name);


### PR DESCRIPTION
Some Abc commands use the hardcoded `/tmp/` directory for temporary files. Over time this will pollute the `/tmp/` directory. To avoid wasting disk space, we introduce the `Abc_GetTmpDir()` function which reads the temporary directory path from environment variables `$TMPDIR` on Linux and `$TMP` or `$TEMP` on windows. If they are not set, it falls back to `/tmp/`.

We update commands that hardcode `/tmp/` to use the new `Abc_GetTmpDir()` function.