### PR TITLE
pdr: add GipSAT, an IC3-specialized SAT solver ported from rIC3 (pdr -s)

### DIFF
--- a/abclib.dsp
+++ b/abclib.dsp
@@ -6998,6 +6998,46 @@ SOURCE=.\src\proof\live\monotone.c
 # PROP Default_Filter ""
 # Begin Source File
 
+SOURCE=.\src\proof\pdr\gipsat\gipAnalyze.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipCdb.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipDomain.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipMain.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipMan.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipProp.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipSearch.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipSimp.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipVsids.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\proof\pdr\gipsat\gipsat.h
+# End Source File
+# Begin Source File
+
 SOURCE=.\src\proof\pdr\pdr.h
 # End Source File
 # Begin Source File

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -33448,7 +33448,7 @@ usage:
     Abc_Print( -2, "\t-c     : * toggle handling CTGs in \'down\' [default = %s]\n",                           pPars->fCtgs? "yes": "no" );
     Abc_Print( -2, "\t-t     : toggle using abstraction [default = %s]\n",                                   pPars->fUseAbs? "yes": "no" );
     Abc_Print( -2, "\t-k     : toggle using simplified refinement [default = %s]\n",                         pPars->fUseSimpleRef? "yes": "no" );
-    Abc_Print( -2, "\t-s     : toggle using the GipSAT solver (ported from rIC3) [default = %s]\n", pPars->fUseGipSat? "yes": "no" );
+    Abc_Print( -2, "\t-s     : toggle using the GipSAT solver (ported from rIC3); -f is recommended [default = %s]\n", pPars->fUseGipSat? "yes": "no" );
     Abc_Print( -2, "\t-v     : toggle printing optimization summary [default = %s]\n",                       pPars->fVerbose? "yes": "no" );
     Abc_Print( -2, "\t-w     : toggle printing detailed stats default = %s]\n",                              pPars->fVeryVerbose? "yes": "no" );
     Abc_Print( -2, "\t-z     : toggle suppressing report about solved outputs [default = %s]\n",             pPars->fNotVerbose? "yes": "no" );

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -33180,7 +33180,7 @@ int Abc_CommandPdr( Abc_Frame_t * pAbc, int argc, char ** argv )
     int c;
     Pdr_ManSetDefaultParams( pPars );
     Extra_UtilGetoptReset();
-    while ( ( c = Extra_UtilGetopt( argc, argv, "MFCDQTHGSLIaxrmuyfqipdegjonctkvwzhb" ) ) != EOF )
+    while ( ( c = Extra_UtilGetopt( argc, argv, "MFCDQTHGSLIaxrmuyfqipdegjonctksvwzhb" ) ) != EOF )
     {
         switch ( c )
         {
@@ -33358,6 +33358,9 @@ int Abc_CommandPdr( Abc_Frame_t * pAbc, int argc, char ** argv )
         case 'k':
             pPars->fUseSimpleRef ^= 1;
             break;
+        case 's':
+            pPars->fUseGipSat ^= 1;
+            break;
         case 'v':
             pPars->fVerbose ^= 1;
             break;
@@ -33411,7 +33414,7 @@ int Abc_CommandPdr( Abc_Frame_t * pAbc, int argc, char ** argv )
     return 0;
 
 usage:
-    Abc_Print( -2, "usage: pdr [-MFCDQTHGS <num>] [-LI <file>] [-axrmuyfqipdegjonctkvwzh]\n" );
+    Abc_Print( -2, "usage: pdr [-MFCDQTHGS <num>] [-LI <file>] [-axrmuyfqipdegjonctksvwzh]\n" );
     Abc_Print( -2, "\t         model checking using property directed reachability (aka IC3)\n" );
     Abc_Print( -2, "\t         pioneered by Aaron R. Bradley (http://theory.stanford.edu/~arbrad/)\n" );
     Abc_Print( -2, "\t         with improvements by Niklas Een (http://een.se/niklas/)\n" );
@@ -33445,6 +33448,7 @@ usage:
     Abc_Print( -2, "\t-c     : * toggle handling CTGs in \'down\' [default = %s]\n",                           pPars->fCtgs? "yes": "no" );
     Abc_Print( -2, "\t-t     : toggle using abstraction [default = %s]\n",                                   pPars->fUseAbs? "yes": "no" );
     Abc_Print( -2, "\t-k     : toggle using simplified refinement [default = %s]\n",                         pPars->fUseSimpleRef? "yes": "no" );
+    Abc_Print( -2, "\t-s     : toggle using the GipSAT solver (ported from rIC3) [default = %s]\n", pPars->fUseGipSat? "yes": "no" );
     Abc_Print( -2, "\t-v     : toggle printing optimization summary [default = %s]\n",                       pPars->fVerbose? "yes": "no" );
     Abc_Print( -2, "\t-w     : toggle printing detailed stats default = %s]\n",                              pPars->fVeryVerbose? "yes": "no" );
     Abc_Print( -2, "\t-z     : toggle suppressing report about solved outputs [default = %s]\n",             pPars->fNotVerbose? "yes": "no" );

--- a/src/proof/pdr/gipsat/gipAnalyze.c
+++ b/src/proof/pdr/gipsat/gipAnalyze.c
@@ -1,0 +1,226 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+#define GIP_MARK_UNSEEN     0
+#define GIP_MARK_SEEN       1
+#define GIP_MARK_REMOVABLE  2
+#define GIP_MARK_FAILED     3
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+static inline int  Gip_Seen( Gip_Solver_t * p, int Lit )   { return p->pMark[Gip_LitVar(Lit)] != GIP_MARK_UNSEEN; }
+static inline void Gip_See( Gip_Solver_t * p, int Lit )    { p->pMark[Gip_LitVar(Lit)] = GIP_MARK_SEEN; Vec_IntPush(p->vClear, Lit); }
+static inline void Gip_MarkAs( Gip_Solver_t * p, int Lit, int m ) { p->pMark[Gip_LitVar(Lit)] = (char)m; Vec_IntPush(p->vClear, Lit); }
+static inline void Gip_ClearMarks( Gip_Solver_t * p )
+{
+    int i, Lit;
+    Vec_IntForEachEntry( p->vClear, Lit, i )
+        p->pMark[Gip_LitVar(Lit)] = GIP_MARK_UNSEEN;
+    Vec_IntClear( p->vClear );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Checks whether a learnt literal is redundant.]
+
+  Description [Iterative DFS over reason clauses with an explicit stack
+  of (lit, resume index) pairs.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static int Gip_SolverLitRedundant( Gip_Solver_t * p, int Lit )
+{
+    Vec_Int_t * vStack = p->vAnaStack;   // pairs (lit, idx)
+    if ( p->pReason[Gip_LitVar(Lit)] == GIP_CREF_NONE )
+        return 0;
+    Vec_IntClear( vStack );
+    Vec_IntPushTwo( vStack, Lit, 1 );
+    while ( Vec_IntSize(vStack) > 0 )
+    {
+        int b = Vec_IntPop( vStack );
+        int q = Vec_IntPop( vStack );
+        int Cref = p->pReason[Gip_LitVar(q)];
+        int * pLits = Gip_ClaLits( &p->Cdb.Alloc, Cref );
+        int nLits = Gip_ClaLen( &p->Cdb.Alloc, Cref );
+        int i, fDescend = 0;
+        for ( i = b; i < nLits; i++ )
+        {
+            int l = pLits[i];
+            int m = p->pMark[Gip_LitVar(l)];
+            if ( p->pLevel[Gip_LitVar(l)] == 0 || m == GIP_MARK_SEEN || m == GIP_MARK_REMOVABLE )
+                continue;
+            if ( p->pReason[Gip_LitVar(l)] == GIP_CREF_NONE || m == GIP_MARK_FAILED )
+            {
+                int j;
+                Vec_IntPushTwo( vStack, q, 0 );
+                for ( j = 0; j < Vec_IntSize(vStack); j += 2 )
+                {
+                    int sl = Vec_IntEntry( vStack, j );
+                    if ( p->pMark[Gip_LitVar(sl)] == GIP_MARK_UNSEEN )
+                        Gip_MarkAs( p, sl, GIP_MARK_FAILED );
+                }
+                return 0;
+            }
+            Vec_IntPushTwo( vStack, q, i + 1 );
+            Vec_IntPushTwo( vStack, l, 1 );
+            fDescend = 1;
+            break;
+        }
+        if ( fDescend )
+            continue;
+        if ( p->pMark[Gip_LitVar(q)] == GIP_MARK_UNSEEN )
+            Gip_MarkAs( p, q, GIP_MARK_REMOVABLE );
+    }
+    return 1;
+}
+
+static void Gip_SolverMinimalLearnt( Gip_Solver_t * p, Vec_Int_t * vLearnt )
+{
+    int i, now = 1;
+    for ( i = 1; i < Vec_IntSize(vLearnt); i++ )
+        if ( !Gip_SolverLitRedundant(p, Vec_IntEntry(vLearnt, i)) )
+            Vec_IntWriteEntry( vLearnt, now++, Vec_IntEntry(vLearnt, i) );
+    Vec_IntShrink( vLearnt, now );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [1-UIP conflict analysis.]
+
+  Description [Fills vLearnt (first literal is the asserting one, second
+  has the max level) and returns the backtrack level.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverAnalyze( Gip_Solver_t * p, int Conflict, Vec_Int_t * vLearnt )
+{
+    int path = 0;
+    int trailIdx = Vec_IntSize( p->vTrail ) - 1;
+    int resolveLit = -1;
+    int i, btl;
+    Vec_IntClear( vLearnt );
+    Vec_IntPush( vLearnt, 0 );   // placeholder for the asserting literal
+    while ( 1 )
+    {
+        int * pLits, nLits, begin, tl;
+        Gip_CdbBump( &p->Cdb, Conflict );
+        pLits = Gip_ClaLits( &p->Cdb.Alloc, Conflict );
+        nLits = Gip_ClaLen( &p->Cdb.Alloc, Conflict );
+        begin = resolveLit != -1 ? 1 : 0;
+        for ( i = begin; i < nLits; i++ )
+        {
+            int Lit = pLits[i];
+            int Var = Gip_LitVar( Lit );
+            if ( !Gip_Seen(p, Lit) && p->pLevel[Var] > 0 )
+            {
+                if ( Var != p->constrainAct )
+                    Gip_VsidsBump( &p->Vsids, Var );
+                p->pMark[Var] = GIP_MARK_SEEN;   // no clear-list push (cleared below)
+                if ( p->pLevel[Var] >= (unsigned)Gip_SolverLevelOf(p) )
+                    path++;
+                else
+                    Vec_IntPush( vLearnt, Lit );
+            }
+        }
+        while ( !Gip_Seen(p, Vec_IntEntry(p->vTrail, trailIdx)) )
+            trailIdx--;
+        tl = Vec_IntEntry( p->vTrail, trailIdx );
+        p->pMark[Gip_LitVar(tl)] = GIP_MARK_UNSEEN;
+        resolveLit = tl;
+        path--;
+        if ( path == 0 )
+            break;
+        Conflict = p->pReason[Gip_LitVar(tl)];
+    }
+    Vec_IntWriteEntry( vLearnt, 0, Gip_LitNot(resolveLit) );
+    for ( i = 0; i < Vec_IntSize(vLearnt); i++ )
+        Vec_IntPush( p->vClear, Vec_IntEntry(vLearnt, i) );
+    Gip_SolverMinimalLearnt( p, vLearnt );
+    Gip_ClearMarks( p );
+    // backtrack level = second-highest level; swap it into position 1
+    if ( Vec_IntSize(vLearnt) == 1 )
+        btl = 0;
+    else
+    {
+        int maxIdx = 1;
+        for ( i = 2; i < Vec_IntSize(vLearnt); i++ )
+            if ( p->pLevel[Gip_LitVar(Vec_IntEntry(vLearnt, i))] >
+                 p->pLevel[Gip_LitVar(Vec_IntEntry(vLearnt, maxIdx))] )
+                maxIdx = i;
+        {
+            int t = Vec_IntEntry( vLearnt, 1 );
+            Vec_IntWriteEntry( vLearnt, 1, Vec_IntEntry(vLearnt, maxIdx) );
+            Vec_IntWriteEntry( vLearnt, maxIdx, t );
+        }
+        btl = (int)p->pLevel[Gip_LitVar(Vec_IntEntry(vLearnt, 1))];
+    }
+    return btl;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Unsat core extraction when an assumption is falsified.]
+
+  Description [Walks the trail backwards from the top to the first
+  assumption position, collecting decision/assumption literals reachable
+  from the falsified assumption.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverAnalyzeUnsatCore( Gip_Solver_t * p, int Lit )
+{
+    int i;
+    Gip_LitSetClear( &p->UnsatCore );
+    Gip_LitSetInsert( &p->UnsatCore, Lit );
+    if ( Gip_SolverLevelOf(p) == 0 )
+        return;
+    Gip_See( p, Lit );
+    for ( i = Vec_IntSize(p->vTrail) - 1; i >= Vec_IntEntry(p->vPosInTrail, 0); i-- )
+    {
+        int pl = Vec_IntEntry( p->vTrail, i );
+        if ( !Gip_Seen(p, pl) )
+            continue;
+        if ( p->pReason[Gip_LitVar(pl)] != GIP_CREF_NONE )
+        {
+            int Cref = p->pReason[Gip_LitVar(pl)];
+            int * pLits = Gip_ClaLits( &p->Cdb.Alloc, Cref );
+            int nLits = Gip_ClaLen( &p->Cdb.Alloc, Cref );
+            int j;
+            for ( j = 1; j < nLits; j++ )
+                if ( p->pLevel[Gip_LitVar(pLits[j])] > 0 )
+                    Gip_See( p, pLits[j] );
+        }
+        else
+            Gip_LitSetInsert( &p->UnsatCore, pl );
+    }
+    Gip_ClearMarks( p );
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipCdb.c
+++ b/src/proof/pdr/gipsat/gipCdb.c
@@ -1,0 +1,363 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+#define GIP_ALLOC_MIN (1 << 20)   // 1M words
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+static void Gip_AllocInit( Gip_Alloc_t * p, unsigned nCapacity )
+{
+    p->nCap = Abc_MaxInt( nCapacity, GIP_ALLOC_MIN );
+    p->pData = ABC_ALLOC( unsigned, p->nCap );
+    p->nSize = 0;
+    p->nWasted = 0;
+}
+
+static void Gip_AllocGrow( Gip_Alloc_t * p, unsigned nWords )
+{
+    if ( p->nSize + nWords <= p->nCap )
+        return;
+    while ( p->nSize + nWords > p->nCap )
+        p->nCap *= 2;
+    p->pData = ABC_REALLOC( unsigned, p->pData, p->nCap );
+}
+
+// clause words: 1 header + nLits + (learnt ? 1 : 0)
+static inline unsigned Gip_ClaWords( Gip_Alloc_t * p, int Cref )
+{
+    return 1 + (unsigned)Gip_ClaLen(p, Cref) + (unsigned)Gip_ClaIsLearnt(p, Cref);
+}
+
+static int Gip_AllocClause( Gip_Alloc_t * p, int * pLits, int nLits, int fTrans, int fLearnt )
+{
+    int cid, i;
+    unsigned nWords = 1 + (unsigned)nLits + (unsigned)(fLearnt != 0);
+    assert( !(fTrans && fLearnt) );
+    Gip_AllocGrow( p, nWords );
+    cid = (int)p->nSize;
+    p->pData[cid] = ((unsigned)nLits << 5) | (unsigned)(fTrans != 0) | ((unsigned)(fLearnt != 0) << 1);
+    for ( i = 0; i < nLits; i++ )
+        p->pData[cid + 1 + i] = (unsigned)pLits[i];
+    if ( fLearnt )
+    {
+        float zero = 0.0;
+        memcpy( p->pData + cid + 1 + nLits, &zero, 4 );
+    }
+    p->nSize += nWords;
+    assert( p->nSize < (unsigned)GIP_CREF_NONE );
+    return cid;
+}
+
+static int Gip_AllocFrom( Gip_Alloc_t * p, unsigned * pFrom, unsigned nWords )
+{
+    int cid;
+    Gip_AllocGrow( p, nWords );
+    cid = (int)p->nSize;
+    memcpy( p->pData + cid, pFrom, sizeof(unsigned) * nWords );
+    p->nSize += nWords;
+    return cid;
+}
+
+// relocate clause into new arena; forwarding pointer stored in lits[0] slot
+static int Gip_AllocReloc( Gip_Alloc_t * pFrom, int Cref, Gip_Alloc_t * pTo )
+{
+    unsigned nWords;
+    int rcid;
+    if ( Gip_ClaIsReloced(pFrom, Cref) )
+        return (int)pFrom->pData[Cref + 1];
+    nWords = Gip_ClaWords( pFrom, Cref );
+    rcid = Gip_AllocFrom( pTo, pFrom->pData + Cref, nWords );
+    Gip_ClaSetReloced( pFrom, Cref );
+    pFrom->pData[Cref + 1] = (unsigned)rcid;
+    return rcid;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Initializes the clause database.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_CdbInit( Gip_Cdb_t * p )
+{
+    Gip_AllocInit( &p->Alloc, GIP_ALLOC_MIN );
+    p->vTrans  = Vec_IntAlloc( 1000 );
+    p->vLemmas = Vec_IntAlloc( 100 );
+    p->vLearnt = Vec_IntAlloc( 100 );
+    p->vTemp   = Vec_IntAlloc( 16 );
+    p->actInc  = 1.0;
+}
+
+void Gip_CdbFree( Gip_Cdb_t * p )
+{
+    ABC_FREE( p->Alloc.pData );
+    Vec_IntFreeP( &p->vTrans );
+    Vec_IntFreeP( &p->vLemmas );
+    Vec_IntFreeP( &p->vLearnt );
+    Vec_IntFreeP( &p->vTemp );
+}
+
+static int Gip_CdbAlloc( Gip_Cdb_t * p, int * pLits, int nLits, int Kind )
+{
+    int cid = Gip_AllocClause( &p->Alloc, pLits, nLits, Kind == GIP_CLA_TRANS, Kind == GIP_CLA_LEARNT );
+    switch ( Kind )
+    {
+        case GIP_CLA_TRANS:     Vec_IntPush( p->vTrans,  cid ); break;
+        case GIP_CLA_LEMMA:     Vec_IntPush( p->vLemmas, cid ); break;
+        case GIP_CLA_LEARNT:    Vec_IntPush( p->vLearnt, cid ); break;
+        case GIP_CLA_TEMPORARY: Vec_IntPush( p->vTemp,   cid ); break;
+        default: assert( 0 );
+    }
+    return cid;
+}
+
+static void Gip_CdbFreeClause( Gip_Cdb_t * p, int Cref )
+{
+    Gip_ClaSetRemoved( &p->Alloc, Cref );
+    p->Alloc.nWasted += Gip_ClaWords( &p->Alloc, Cref );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Bumps the activity of a learnt clause.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_CdbBump( Gip_Cdb_t * p, int Cref )
+{
+    float act;
+    if ( !Gip_ClaIsLearnt(&p->Alloc, Cref) )
+        return;
+    act = Gip_ClaAct( &p->Alloc, Cref ) + p->actInc;
+    Gip_ClaSetAct( &p->Alloc, Cref, act );
+    if ( act > (float)1e20 )
+    {
+        int i, l;
+        Vec_IntForEachEntry( p->vLearnt, l, i )
+            Gip_ClaSetAct( &p->Alloc, l, Gip_ClaAct(&p->Alloc, l) * (float)1e-20 );
+        p->actInc *= (float)1e-20;
+    }
+}
+
+void Gip_CdbDecay( Gip_Cdb_t * p )
+{
+    p->actInc *= (float)(1.0 / 0.99);
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Attaches a clause to the database and the watchers.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverAttachClause( Gip_Solver_t * p, int * pLits, int nLits, int Kind )
+{
+    int cid;
+    assert( nLits > 1 );
+    cid = Gip_CdbAlloc( &p->Cdb, pLits, nLits, Kind );
+    Gip_WatchersAttach( p, cid );
+    return cid;
+}
+
+void Gip_SolverDetachClause( Gip_Solver_t * p, int Cref )
+{
+    Gip_WatchersDetach( p, Cref );
+    Gip_CdbFreeClause( &p->Cdb, Cref );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Removes all temporary clauses and the constrainAct assignment.]
+
+  Description [Unlike rIC3, nPropagated is decremented for every removed
+  trail entry below the propagation frontier, keeping BCP consistent.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverCleanTemporary( Gip_Solver_t * p )
+{
+    while ( Vec_IntSize(p->Cdb.vTemp) > 0 )
+        Gip_SolverDetachClause( p, Vec_IntPop(p->Cdb.vTemp) );
+    if ( p->pValue[p->constrainAct] != GIP_NONE )
+    {
+        int i, Lit, k = 0;
+        Vec_IntForEachEntry( p->vTrail, Lit, i )
+        {
+            if ( Gip_LitVar(Lit) != p->constrainAct )
+                Vec_IntWriteEntry( p->vTrail, k++, Lit );
+            else if ( i < p->nPropagated )
+                p->nPropagated--;
+        }
+        Vec_IntShrink( p->vTrail, k );
+        Gip_SolverSetNone( p, p->constrainAct );
+    }
+}
+
+static int Gip_SolverLocked( Gip_Solver_t * p, int Cref )
+{
+    int Lit0 = Gip_ClaLits( &p->Cdb.Alloc, Cref )[0];
+    return Gip_SolverLitValue( p, Lit0 ) == GIP_TRUE && p->pReason[Gip_LitVar(Lit0)] == Cref;
+}
+
+// sort helper for clean_learnt: descending activity
+typedef struct Gip_ActPair_t_ { float act; int cref; } Gip_ActPair_t;
+static int Gip_ActPairCmp( const void * a, const void * b )
+{
+    float fa = ((Gip_ActPair_t *)a)->act, fb = ((Gip_ActPair_t *)b)->act;
+    if ( fa > fb ) return -1;
+    if ( fa < fb ) return 1;
+    return 0;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Reduces the learnt clause set.]
+
+  Description [Keeps the top third by activity; below that keeps only
+  locked or binary clauses; then garbage-collects.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverCleanLearnt( Gip_Solver_t * p, int fFull )
+{
+    int nLearnt = Vec_IntSize( p->Cdb.vLearnt );
+    int nTrans  = Vec_IntSize( p->Cdb.vTrans );
+    Gip_ActPair_t * pPairs;
+    int i, l;
+    abctime clk;
+    if ( !( (fFull && nLearnt * 15 > nTrans) || nLearnt > nTrans ) )
+        return;
+    clk = Abc_Clock();
+    pPairs = ABC_ALLOC( Gip_ActPair_t, nLearnt );
+    Vec_IntForEachEntry( p->Cdb.vLearnt, l, i )
+    {
+        pPairs[i].act  = Gip_ClaAct( &p->Cdb.Alloc, l );
+        pPairs[i].cref = l;
+    }
+    qsort( pPairs, (size_t)nLearnt, sizeof(Gip_ActPair_t), Gip_ActPairCmp );
+    Vec_IntClear( p->Cdb.vLearnt );
+    for ( i = 0; i < nLearnt; i++ )
+    {
+        l = pPairs[i].cref;
+        if ( i > nLearnt / 3 && !Gip_SolverLocked(p, l) && Gip_ClaLen(&p->Cdb.Alloc, l) > 2 )
+            Gip_SolverDetachClause( p, l );
+        else
+            Vec_IntPush( p->Cdb.vLearnt, l );
+    }
+    ABC_FREE( pPairs );
+    Gip_SolverGarbageCollect( p );
+    p->Stats.timeCleanL += Abc_Clock() - clk;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Removes one literal in place (self-subsumption).]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverStrengthenClause( Gip_Solver_t * p, int Cref, int Lit )
+{
+    Gip_Alloc_t * pA = &p->Cdb.Alloc;
+    int * pLits = Gip_ClaLits( pA, Cref );
+    int nLits = Gip_ClaLen( pA, Cref );
+    int pos, fLearnt = Gip_ClaIsLearnt( pA, Cref );
+    assert( nLits > 2 );
+    for ( pos = 0; pos < nLits; pos++ )
+        if ( pLits[pos] == Lit )
+            break;
+    assert( pos < nLits );
+    Gip_WatchersDetach( p, Cref );
+    // swap_remove: move last literal into pos; if learnt, move the
+    // activity word into the freed literal slot
+    pLits[pos] = pLits[nLits-1];
+    if ( fLearnt )
+        pA->pData[Cref + nLits] = pA->pData[Cref + nLits + 1];
+    Gip_ClaSetLen( pA, Cref, nLits - 1 );
+    Gip_WatchersAttach( p, Cref );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Compacts the arena when a third of it is wasted.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverGarbageCollect( Gip_Solver_t * p )
+{
+    Gip_Alloc_t * pOld = &p->Cdb.Alloc;
+    Gip_Alloc_t New;
+    int i, j, Lit, Cref;
+    if ( pOld->nWasted * 3 <= pOld->nSize )
+        return;
+    Gip_AllocInit( &New, pOld->nSize - pOld->nWasted );
+    // watchers
+    for ( i = 0; i < 2 * p->nVarsAlloc; i++ )
+        for ( j = 0; j < p->pWatchers[i].nSize; j++ )
+            p->pWatchers[i].pArray[j].clause = Gip_AllocReloc( pOld, p->pWatchers[i].pArray[j].clause, &New );
+    // clause lists
+    Vec_IntForEachEntry( p->Cdb.vTrans, Cref, i )
+        Vec_IntWriteEntry( p->Cdb.vTrans, i, Gip_AllocReloc(pOld, Cref, &New) );
+    Vec_IntForEachEntry( p->Cdb.vLemmas, Cref, i )
+        Vec_IntWriteEntry( p->Cdb.vLemmas, i, Gip_AllocReloc(pOld, Cref, &New) );
+    Vec_IntForEachEntry( p->Cdb.vLearnt, Cref, i )
+        Vec_IntWriteEntry( p->Cdb.vLearnt, i, Gip_AllocReloc(pOld, Cref, &New) );
+    Vec_IntForEachEntry( p->Cdb.vTemp, Cref, i )
+        Vec_IntWriteEntry( p->Cdb.vTemp, i, Gip_AllocReloc(pOld, Cref, &New) );
+    // reasons of trail literals
+    Vec_IntForEachEntry( p->vTrail, Lit, i )
+        if ( p->pReason[Gip_LitVar(Lit)] != GIP_CREF_NONE )
+            p->pReason[Gip_LitVar(Lit)] = Gip_AllocReloc( pOld, p->pReason[Gip_LitVar(Lit)], &New );
+    ABC_FREE( pOld->pData );
+    p->Cdb.Alloc = New;
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipDomain.c
+++ b/src/proof/pdr/gipsat/gipDomain.c
@@ -1,0 +1,265 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+static inline int * Gip_CtxDep( Gip_Ctx_t * p, int Var, int * pnDeps )
+{
+    *pnDeps = p->pDepOffset[Var+1] - p->pDepOffset[Var];
+    return p->pDepData + p->pDepOffset[Var];
+}
+
+void Gip_VarSetInit( Gip_VarSet_t * p, int nVarsAlloc )
+{
+    p->vSet = Vec_IntAlloc( 100 );
+    p->pHas = ABC_CALLOC( char, nVarsAlloc );
+}
+
+void Gip_VarSetFree( Gip_VarSet_t * p )
+{
+    Vec_IntFreeP( &p->vSet );
+    ABC_FREE( p->pHas );
+}
+
+void Gip_LitSetInit( Gip_LitSet_t * p, int nVarsAlloc )
+{
+    p->vSet = Vec_IntAlloc( 100 );
+    p->pHas = ABC_CALLOC( char, 2 * nVarsAlloc );
+}
+
+void Gip_LitSetFree( Gip_LitSet_t * p )
+{
+    Vec_IntFreeP( &p->vSet );
+    ABC_FREE( p->pHas );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Initializes the domain; the constant var is permanent.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_DomainInit( Gip_Domain_t * p, int nVarsAlloc, int varConst )
+{
+    Gip_VarSetInit( &p->Set, nVarsAlloc );
+    Gip_VarSetInsert( &p->Set, varConst );
+    p->nFixed = 1;
+}
+
+void Gip_DomainFree( Gip_Domain_t * p )
+{
+    Gip_VarSetFree( &p->Set );
+}
+
+// drop everything after the fixed prefix
+void Gip_DomainReset( Gip_Domain_t * p )
+{
+    while ( Vec_IntSize(p->Set.vSet) > p->nFixed )
+        p->Set.pHas[ Vec_IntPop(p->Set.vSet) ] = 0;
+}
+
+int Gip_DomainHas( Gip_Domain_t * p, int Var )
+{
+    return Gip_VarSetHas( &p->Set, Var );
+}
+
+void Gip_DomainInsert( Gip_Domain_t * p, int Var )
+{
+    Gip_VarSetInsert( &p->Set, Var );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Per-query local domain = dep closure of the seeds.]
+
+  Description [BFS from index nFixed following the dep table.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_DomainEnableLocal( Gip_Solver_t * p, Vec_Int_t * vSeeds )
+{
+    Gip_Domain_t * pDom = &p->Domain;
+    int i, v, now;
+    Gip_DomainReset( pDom );
+    Vec_IntForEachEntry( vSeeds, v, i )
+        Gip_DomainInsert( pDom, v );
+    now = pDom->nFixed;
+    while ( now < Vec_IntSize(pDom->Set.vSet) )
+    {
+        int nDeps, j, * pDeps;
+        v = Vec_IntEntry( pDom->Set.vSet, now );
+        now++;
+        pDeps = Gip_CtxDep( p->pCtx, v, &nDeps );
+        for ( j = 0; j < nDeps; j++ )
+            Gip_DomainInsert( pDom, pDeps[j] );
+    }
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Permanently adds a variable and its dep closure.]
+
+  Description [Called for every literal of every added lemma clause.
+  Extends the fixed prefix; skips already-assigned vars.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverAddDomain( Gip_Solver_t * p, int Var, int fDeps )
+{
+    Gip_Domain_t * pDom = &p->Domain;
+    assert( Gip_SolverLevelOf(p) == 0 );
+    if ( p->pValue[Var] != GIP_NONE )
+        return;
+    Gip_DomainReset( pDom );
+    Gip_VarSetInsert( &pDom->Set, Var );
+    if ( fDeps )
+    {
+        Vec_Int_t * vQueue = p->vSeeds; // scratch (safe: not used concurrently)
+        int nDeps, j, d, * pDeps;
+        Vec_IntClear( vQueue );
+        pDeps = Gip_CtxDep( p->pCtx, Var, &nDeps );
+        for ( j = 0; j < nDeps; j++ )
+            Vec_IntPush( vQueue, pDeps[j] );
+        while ( Vec_IntSize(vQueue) > 0 )
+        {
+            d = Vec_IntPop( vQueue );
+            if ( Gip_VarSetHas(&pDom->Set, d) )
+                continue;
+            Gip_VarSetInsert( &pDom->Set, d );
+            pDeps = Gip_CtxDep( p->pCtx, d, &nDeps );
+            for ( j = 0; j < nDeps; j++ )
+                Vec_IntPush( vQueue, pDeps[j] );
+        }
+    }
+    pDom->nFixed = Vec_IntSize( pDom->Set.vSet );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Pushes all unassigned domain vars into VSIDS.]
+
+  Description [Also lazily compacts the fixed prefix: assigned fixed
+  vars are removed for good.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static void Gip_SolverPushToVsids( Gip_Solver_t * p )
+{
+    Gip_Domain_t * pDom = &p->Domain;
+    int now = 0, d;
+    assert( Gip_SolverLevelOf(p) == 0 );
+    while ( now < pDom->nFixed )
+    {
+        d = Vec_IntEntry( pDom->Set.vSet, now );
+        if ( p->pValue[d] == GIP_NONE )
+        {
+            Gip_VsidsPush( &p->Vsids, d );
+            now++;
+        }
+        else
+        {
+            // swap set[now] <-> set[nFixed-1], then swap-remove index nFixed-1
+            int last = Vec_IntEntry( pDom->Set.vSet, pDom->nFixed - 1 );
+            Vec_IntWriteEntry( pDom->Set.vSet, now, last );
+            Vec_IntWriteEntry( pDom->Set.vSet, pDom->nFixed - 1, d );
+            pDom->Set.pHas[d] = 0;
+            Vec_IntWriteEntry( pDom->Set.vSet, pDom->nFixed - 1, Vec_IntEntryLast(pDom->Set.vSet) );
+            Vec_IntPop( pDom->Set.vSet );
+            pDom->nFixed--;
+        }
+    }
+    while ( now < Vec_IntSize(pDom->Set.vSet) )
+    {
+        Gip_VsidsPush( &p->Vsids, Vec_IntEntry(pDom->Set.vSet, now) );
+        now++;
+    }
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Fixes a temporary domain for a whole MIC round.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverSetDomain( Gip_Solver_t * p, int * pLits, int nLits )
+{
+    int i;
+    Vec_IntClear( p->vSeeds );
+    for ( i = 0; i < nLits; i++ )
+        Vec_IntPush( p->vSeeds, Gip_LitVar(pLits[i]) );
+    Gip_SolverReset( p );
+    p->fTempDomain = 1;
+    Gip_DomainEnableLocal( p, p->vSeeds );
+    assert( !Gip_DomainHas(&p->Domain, p->constrainAct) );
+    Gip_DomainInsert( &p->Domain, p->constrainAct );
+    p->Vsids.fEnableBucket = 1;
+    Gip_BucketClear( &p->Vsids.Bucket );
+    Gip_SolverPushToVsids( p );
+}
+
+void Gip_SolverUnsetDomain( Gip_Solver_t * p )
+{
+    p->fTempDomain = 0;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Late VSIDS fill, once all assumptions are placed.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverPrepareVsids( Gip_Solver_t * p )
+{
+    int i, d;
+    if ( !p->fPreparedVsids && !p->fTempDomain )
+    {
+        p->fPreparedVsids = 1;
+        Vec_IntForEachEntry( p->Domain.Set.vSet, d, i )
+            if ( p->pValue[d] == GIP_NONE )
+                Gip_VsidsPush( &p->Vsids, d );
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipMain.c
+++ b/src/proof/pdr/gipsat/gipMain.c
@@ -1,0 +1,393 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+static int Gip_SolverSimplifyClause( Gip_Solver_t * p, int * pLits, int nLits );
+
+/**Function*************************************************************
+
+  Synopsis    [Creates a solver over the shared context.]
+
+  Description [Loads the entire static CNF as transition clauses.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+Gip_Solver_t * Gip_SolverNew( Gip_Ctx_t * pCtx )
+{
+    Gip_Solver_t * p = ABC_CALLOC( Gip_Solver_t, 1 );
+    int i, c, Conflict;
+    p->pCtx = pCtx;
+    p->nVars = pCtx->nVars;
+    p->constrainAct = pCtx->nVars;
+    p->nVarsAlloc = pCtx->nVars + 1;
+    p->pValue  = ABC_ALLOC( char, p->nVarsAlloc );
+    p->pPhase  = ABC_ALLOC( char, p->nVarsAlloc );
+    p->pMark   = ABC_CALLOC( char, p->nVarsAlloc );
+    p->pLevel  = ABC_CALLOC( unsigned, p->nVarsAlloc );
+    p->pReason = ABC_ALLOC( int, p->nVarsAlloc );
+    for ( i = 0; i < p->nVarsAlloc; i++ )
+    {
+        p->pValue[i]  = GIP_NONE;
+        p->pPhase[i]  = GIP_NONE;
+        p->pReason[i] = GIP_CREF_NONE;
+    }
+    p->pWatchers = ABC_CALLOC( Gip_WVec_t, 2 * p->nVarsAlloc );
+    Gip_CdbInit( &p->Cdb );
+    Gip_VsidsInit( &p->Vsids, p->nVarsAlloc );
+    Gip_DomainInit( &p->Domain, p->nVarsAlloc, pCtx->varConst );
+    Gip_LitSetInit( &p->UnsatCore, p->nVarsAlloc );
+    p->vTrail      = Vec_IntAlloc( 1000 );
+    p->vPosInTrail = Vec_IntAlloc( 100 );
+    p->vClear      = Vec_IntAlloc( 100 );
+    p->vAnaStack   = Vec_IntAlloc( 100 );
+    p->vLearntCls  = Vec_IntAlloc( 100 );
+    p->vSimpCls    = Vec_IntAlloc( 100 );
+    p->vSeeds      = Vec_IntAlloc( 100 );
+    p->vAssump     = Vec_IntAlloc( 16 );
+    p->nLastNumLemma = 1000;
+    for ( c = 0; c < pCtx->pCnf->nClauses; c++ )
+        Gip_SolverAddClauseInner( p, pCtx->pCnf->pClauses[c],
+            (int)(pCtx->pCnf->pClauses[c+1] - pCtx->pCnf->pClauses[c]), GIP_CLA_TRANS );
+    Conflict = Gip_SolverPropagate( p );
+    assert( Conflict == GIP_CREF_NONE );
+    assert( !p->fTrivialUnsat );
+    return p;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Frees the solver.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverFree( Gip_Solver_t * p )
+{
+    int i;
+    if ( p == NULL )
+        return;
+    for ( i = 0; i < 2 * p->nVarsAlloc; i++ )
+        ABC_FREE( p->pWatchers[i].pArray );
+    ABC_FREE( p->pWatchers );
+    ABC_FREE( p->pValue );
+    ABC_FREE( p->pPhase );
+    ABC_FREE( p->pMark );
+    ABC_FREE( p->pLevel );
+    ABC_FREE( p->pReason );
+    Gip_CdbFree( &p->Cdb );
+    Gip_VsidsFree( &p->Vsids );
+    Gip_DomainFree( &p->Domain );
+    Gip_LitSetFree( &p->UnsatCore );
+    Vec_IntFreeP( &p->vTrail );
+    Vec_IntFreeP( &p->vPosInTrail );
+    Vec_IntFreeP( &p->vClear );
+    Vec_IntFreeP( &p->vAnaStack );
+    Vec_IntFreeP( &p->vLearntCls );
+    Vec_IntFreeP( &p->vSimpCls );
+    Vec_IntFreeP( &p->vSeeds );
+    Vec_IntFreeP( &p->vAssump );
+    ABC_FREE( p );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Level-0 clause simplification.]
+
+  Description [Sorts literals, drops duplicates and false literals,
+  detects tautologies and satisfied clauses. Fills p->vSimpCls. Returns
+  0 if the clause should be dropped; an empty result sets fTrivialUnsat.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static int Gip_SolverSimplifyClause( Gip_Solver_t * p, int * pLits, int nLits )
+{
+    int i, k = 0, prev = -1;
+    assert( Gip_SolverLevelOf(p) == 0 );
+    Vec_IntClear( p->vSimpCls );
+    for ( i = 0; i < nLits; i++ )
+        Vec_IntPush( p->vSimpCls, pLits[i] );
+    Vec_IntSort( p->vSimpCls, 0 );
+    for ( i = 0; i < Vec_IntSize(p->vSimpCls); i++ )
+    {
+        int Lit = Vec_IntEntry( p->vSimpCls, i );
+        int v;
+        if ( Lit == prev )
+            continue;
+        if ( prev != -1 && Lit == Gip_LitNot(prev) )
+            return 0;
+        prev = Lit;
+        v = Gip_SolverLitValue( p, Lit );
+        if ( v == GIP_TRUE )
+            return 0;
+        if ( v == GIP_FALSE )
+            continue;
+        Vec_IntWriteEntry( p->vSimpCls, k++, Lit );
+    }
+    Vec_IntShrink( p->vSimpCls, k );
+    if ( k == 0 )
+    {
+        p->fTrivialUnsat = 1;
+        return 0;
+    }
+    return 1;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Simplifies and attaches a clause; returns CRef or GIP_CREF_NONE.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverAddClauseInner( Gip_Solver_t * p, int * pLits, int nLits, int Kind )
+{
+    int i, Lit;
+    if ( !Gip_SolverSimplifyClause( p, pLits, nLits ) )
+        return GIP_CREF_NONE;
+    Vec_IntForEachEntry( p->vSimpCls, Lit, i )
+        if ( Gip_LitVar(Lit) == p->constrainAct )
+            Kind = GIP_CLA_TEMPORARY;
+    if ( Vec_IntSize(p->vSimpCls) == 1 )
+    {
+        Lit = Vec_IntEntry( p->vSimpCls, 0 );
+        assert( Gip_LitVar(Lit) != p->constrainAct );
+        assert( Gip_SolverLitValue(p, Lit) == GIP_NONE );
+        Gip_SolverAssign( p, Lit, GIP_CREF_NONE );
+        if ( Gip_SolverPropagate(p) != GIP_CREF_NONE )
+            p->fTrivialUnsat = 1;
+        return GIP_CREF_NONE;
+    }
+    return Gip_SolverAttachClause( p, Vec_IntArray(p->vSimpCls), Vec_IntSize(p->vSimpCls), Kind );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Backtracks to level 0 and drops temporaries and local domain.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverReset( Gip_Solver_t * p )
+{
+    Gip_SolverBacktrack( p, 0, 0 );
+    Gip_SolverCleanTemporary( p );
+    p->fPreparedVsids = 0;
+    Gip_DomainReset( &p->Domain );
+    assert( !p->fTempDomain );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Adds a lemma clause.]
+
+  Description [The only external entry for frame cubes; permanently
+  extends the fixed domain with the lemma variables.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverAddLemma( Gip_Solver_t * p, int * pLits, int nLits )
+{
+    int i;
+    Gip_SolverReset( p );
+    for ( i = 0; i < nLits; i++ )
+        Gip_SolverAddDomain( p, Gip_LitVar(pLits[i]), 1 );
+    Gip_SolverAddClauseInner( p, pLits, nLits, GIP_CLA_LEMMA );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Starts a query round.]
+
+  Description [Attaches the constraint clauses as temporaries and builds
+  the local domain from the seeds. Returns 0 if a constraint clause
+  simplifies to a unit (query is UNSAT).]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static int Gip_SolverNewRound( Gip_Solver_t * p, Vec_Int_t * vSeeds,
+                               int ** ppCstCls, int * pnCstLits, int nCst, int fBucket )
+{
+    int c, i;
+    Gip_SolverBacktrack( p, 0, p->fTempDomain );
+    Gip_SolverCleanTemporary( p );
+    p->fPreparedVsids = 0;
+    for ( c = 0; c < nCst; c++ )
+    {
+        Vec_IntClear( p->vAssump );   // scratch here; real assumptions built later
+        for ( i = 0; i < pnCstLits[c]; i++ )
+            Vec_IntPush( p->vAssump, ppCstCls[c][i] );
+        Vec_IntPush( p->vAssump, Gip_Lit(p->constrainAct, 1) );
+        if ( !Gip_SolverSimplifyClause( p, Vec_IntArray(p->vAssump), Vec_IntSize(p->vAssump) ) )
+            continue;
+        assert( Vec_IntSize(p->vSimpCls) > 0 );
+        if ( Vec_IntSize(p->vSimpCls) == 1 )
+            return 0;
+        Gip_SolverAttachClause( p, Vec_IntArray(p->vSimpCls), Vec_IntSize(p->vSimpCls), GIP_CLA_TEMPORARY );
+    }
+    if ( !p->fTempDomain )
+    {
+        Gip_DomainEnableLocal( p, vSeeds );
+        assert( !Gip_DomainHas(&p->Domain, p->constrainAct) );
+        Gip_DomainInsert( &p->Domain, p->constrainAct );
+        if ( fBucket )
+        {
+            p->Vsids.fEnableBucket = 1;
+            Gip_BucketClear( &p->Vsids.Bucket );
+        }
+        else
+        {
+            p->Vsids.fEnableBucket = 0;
+            Gip_HeapClear( &p->Vsids.Heap );
+        }
+    }
+    return 1;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Full query entry point.]
+
+  Description [Solves under the given assumptions and temporary
+  constraint clauses. Returns GIP_SAT/GIP_UNSAT/GIP_UNDEF.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverSolve( Gip_Solver_t * p,
+                     int * pAssump, int nAssump,
+                     int ** ppCstCls, int * pnCstLits, int nCst,
+                     int nRestartLimit )
+{
+    abctime clk;
+    int i, c, res, * pUse, nUse;
+    p->fCanceled = 0;
+    p->nConfCounted = p->Stats.nConflicts;
+    if ( p->fTrivialUnsat )
+    {
+        Gip_LitSetClear( &p->UnsatCore );
+        return GIP_UNSAT;
+    }
+    p->Stats.nSolves++;
+    clk = Abc_Clock();
+    if ( Gip_SolverPropagate(p) != GIP_CREF_NONE )
+    {
+        p->fTrivialUnsat = 1;
+        Gip_LitSetClear( &p->UnsatCore );
+        p->Stats.timeSolve += Abc_Clock() - clk;
+        return GIP_UNSAT;
+    }
+    // domain seeds = assumption vars + constraint vars
+    Vec_IntClear( p->vSeeds );
+    for ( i = 0; i < nAssump; i++ )
+        Vec_IntPush( p->vSeeds, Gip_LitVar(pAssump[i]) );
+    for ( c = 0; c < nCst; c++ )
+        for ( i = 0; i < pnCstLits[c]; i++ )
+            Vec_IntPush( p->vSeeds, Gip_LitVar(ppCstCls[c][i]) );
+    if ( nCst > 0 )
+    {
+        if ( !Gip_SolverNewRound( p, p->vSeeds, ppCstCls, pnCstLits, nCst, 1 ) )
+        {
+            Gip_LitSetClear( &p->UnsatCore );
+            p->Stats.timeSolve += Abc_Clock() - clk;
+            return GIP_UNSAT;
+        }
+        // assumptions = [constrainAct] ++ pAssump
+        Vec_IntClear( p->vAssump );
+        Vec_IntPush( p->vAssump, Gip_Lit(p->constrainAct, 0) );
+        for ( i = 0; i < nAssump; i++ )
+            Vec_IntPush( p->vAssump, pAssump[i] );
+        pUse = Vec_IntArray( p->vAssump );
+        nUse = Vec_IntSize( p->vAssump );
+    }
+    else
+    {
+        res = Gip_SolverNewRound( p, p->vSeeds, NULL, NULL, 0, 1 );
+        assert( res );
+        pUse = pAssump;
+        nUse = nAssump;
+    }
+    Gip_SolverCleanLearnt( p, 1 );
+    Gip_SolverSimplify( p );
+    res = Gip_SolverSearchWithRestart( p, pUse, nUse, nRestartLimit );
+    p->Stats.timeSolve += Abc_Clock() - clk;
+    return res;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Model value of a variable; unassigned counts as 0.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverVarValue( Gip_Solver_t * p, int Var )
+{
+    return p->pValue[Var] == GIP_TRUE ? 1 : 0;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Checks whether a literal is in the last unsat core.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverUnsatHas( Gip_Solver_t * p, int Lit )
+{
+    return Gip_LitSetHas( &p->UnsatCore, Lit );
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipMan.c
+++ b/src/proof/pdr/gipsat/gipMan.c
@@ -1,0 +1,125 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+/**Function*************************************************************
+
+  Synopsis    [Creates the shared GipSAT context.]
+
+  Description [Derives a full static CNF over the entire AIG and builds
+  the CSR dependency table dep(v) = variables appearing in the defining
+  clauses of v. Shared read-only by all frame solvers.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+Gip_Ctx_t * Gip_CtxCreate( Aig_Man_t * pAig, Cnf_Man_t * pCnfMan )
+{
+    Gip_Ctx_t * p;
+    int * pStamp;   // per-var stamp for dedup while collecting deps
+    int * pCount;   // per-var dep count (pass 1)
+    int ObjId, i, c, w, u, nObjs;
+    int * pLit, * pStop;
+    p = ABC_CALLOC( Gip_Ctx_t, 1 );
+    p->pAig  = pAig;
+    p->pCnf  = Cnf_DeriveOtherWithMan( pCnfMan, pAig, 0 );
+    p->nVars = p->pCnf->nVars;
+    assert( p->nVars == Aig_ManObjNumMax(pAig) );
+    p->varConst = Gip_ObjVar( Aig_ManConst1(pAig) );
+    assert( p->varConst >= 0 && p->varConst < p->nVars );
+    nObjs = Aig_ManObjNumMax( pAig );
+
+    // pass 1: count deps per defined var
+    pCount = ABC_CALLOC( int, p->nVars );
+    pStamp = ABC_ALLOC( int, p->nVars );
+    for ( i = 0; i < p->nVars; i++ )
+        pStamp[i] = -1;
+    for ( ObjId = 0; ObjId < nObjs; ObjId++ )
+    {
+        if ( p->pCnf->pObj2Count[ObjId] <= 0 )
+            continue;
+        w = ObjId;
+        for ( c = p->pCnf->pObj2Clause[ObjId]; c < p->pCnf->pObj2Clause[ObjId] + p->pCnf->pObj2Count[ObjId]; c++ )
+            for ( pLit = p->pCnf->pClauses[c], pStop = p->pCnf->pClauses[c+1]; pLit < pStop; pLit++ )
+            {
+                u = Gip_LitVar( *pLit );
+                if ( u == w || pStamp[u] == ObjId )
+                    continue;
+                pStamp[u] = ObjId;
+                pCount[w]++;
+            }
+    }
+    // build offsets
+    p->pDepOffset = ABC_ALLOC( int, p->nVars + 1 );
+    p->pDepOffset[0] = 0;
+    for ( i = 0; i < p->nVars; i++ )
+        p->pDepOffset[i+1] = p->pDepOffset[i] + pCount[i];
+    p->nDepData = p->pDepOffset[p->nVars];
+    p->pDepData = ABC_ALLOC( int, Abc_MaxInt(p->nDepData, 1) );
+    // pass 2: fill
+    memset( pCount, 0, sizeof(int) * p->nVars );
+    for ( i = 0; i < p->nVars; i++ )
+        pStamp[i] = -1;
+    for ( ObjId = 0; ObjId < nObjs; ObjId++ )
+    {
+        if ( p->pCnf->pObj2Count[ObjId] <= 0 )
+            continue;
+        w = ObjId;
+        for ( c = p->pCnf->pObj2Clause[ObjId]; c < p->pCnf->pObj2Clause[ObjId] + p->pCnf->pObj2Count[ObjId]; c++ )
+            for ( pLit = p->pCnf->pClauses[c], pStop = p->pCnf->pClauses[c+1]; pLit < pStop; pLit++ )
+            {
+                u = Gip_LitVar( *pLit );
+                if ( u == w || pStamp[u] == ObjId )
+                    continue;
+                pStamp[u] = ObjId;
+                p->pDepData[ p->pDepOffset[w] + pCount[w]++ ] = u;
+            }
+    }
+    ABC_FREE( pStamp );
+    ABC_FREE( pCount );
+    return p;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Frees the context.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_CtxFree( Gip_Ctx_t * p )
+{
+    if ( p == NULL )
+        return;
+    Cnf_DataFree( p->pCnf );
+    ABC_FREE( p->pDepOffset );
+    ABC_FREE( p->pDepData );
+    ABC_FREE( p );
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipProp.c
+++ b/src/proof/pdr/gipsat/gipProp.c
@@ -1,0 +1,223 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+static inline void Gip_WVecPush( Gip_WVec_t * p, int Cref, int Blocker )
+{
+    if ( p->nSize == p->nCap )
+    {
+        p->nCap = p->nCap ? 2*p->nCap : 4;
+        p->pArray = ABC_REALLOC( Gip_Wat_t, p->pArray, p->nCap );
+    }
+    p->pArray[p->nSize].clause  = Cref;
+    p->pArray[p->nSize].blocker = Blocker;
+    p->nSize++;
+}
+
+static inline void Gip_WVecSwapRemove( Gip_WVec_t * p, int i )
+{
+    p->pArray[i] = p->pArray[p->nSize-1];
+    p->nSize--;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Attaches the first two literals of a clause to the watchers.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_WatchersAttach( Gip_Solver_t * p, int Cref )
+{
+    int * pLits = Gip_ClaLits( &p->Cdb.Alloc, Cref );
+    Gip_WVecPush( &p->pWatchers[Gip_LitNot(pLits[0])], Cref, pLits[1] );
+    Gip_WVecPush( &p->pWatchers[Gip_LitNot(pLits[1])], Cref, pLits[0] );
+}
+
+void Gip_WatchersDetach( Gip_Solver_t * p, int Cref )
+{
+    int * pLits = Gip_ClaLits( &p->Cdb.Alloc, Cref );
+    int k, i;
+    for ( k = 0; k < 2; k++ )
+    {
+        Gip_WVec_t * pW = &p->pWatchers[Gip_LitNot(pLits[k])];
+        for ( i = pW->nSize - 1; i >= 0; i-- )
+            if ( pW->pArray[i].clause == Cref )
+            {
+                Gip_WVecSwapRemove( pW, i );
+                break;
+            }
+    }
+}
+
+// full propagation, used at decision level 0
+static int Gip_SolverPropagateFull( Gip_Solver_t * p )
+{
+    Gip_Alloc_t * pA = &p->Cdb.Alloc;
+    while ( p->nPropagated < Vec_IntSize(p->vTrail) )
+    {
+        int Lit = Vec_IntEntry( p->vTrail, p->nPropagated++ );
+        Gip_WVec_t * pWs = &p->pWatchers[Lit];
+        Gip_Wat_t * pDat = pWs->pArray;
+        int wlen = pWs->nSize;
+        int w = 0;
+        p->Stats.nPropagations++;
+        while ( w < wlen )
+        {
+            int blocker = pDat[w].blocker;
+            int cid, * pLits, c0, len, i;
+            if ( Gip_SolverLitValue(p, blocker) == GIP_TRUE )
+            {
+                w++;
+                continue;
+            }
+            cid = pDat[w].clause;
+            pLits = Gip_ClaLits( pA, cid );
+            if ( pLits[0] == Gip_LitNot(Lit) )
+            {
+                int t = pLits[0]; pLits[0] = pLits[1]; pLits[1] = t;
+            }
+            c0 = pLits[0];
+            if ( c0 != blocker && Gip_SolverLitValue(p, c0) == GIP_TRUE )
+            {
+                pDat[w].blocker = c0;
+                w++;
+                continue;
+            }
+            len = Gip_ClaLen( pA, cid );
+            for ( i = 2; i < len; i++ )
+            {
+                if ( Gip_SolverLitValue(p, pLits[i]) != GIP_FALSE )
+                {
+                    int t = pLits[1]; pLits[1] = pLits[i]; pLits[i] = t;
+                    wlen--;
+                    pDat[w] = pDat[wlen];
+                    Gip_WVecPush( &p->pWatchers[Gip_LitNot(pLits[1])], cid, c0 );
+                    goto next_cls;
+                }
+            }
+            pDat[w].blocker = c0;
+            if ( Gip_SolverLitValue(p, c0) == GIP_FALSE )
+            {
+                pWs->nSize = wlen;
+                return cid;
+            }
+            Gip_SolverAssign( p, c0, cid );
+            w++;
+next_cls:;
+        }
+        pWs->nSize = wlen;
+    }
+    return GIP_CREF_NONE;
+}
+
+// domain-restricted propagation, used at levels > 0: clauses watched by
+// out-of-domain variables are skipped, so variables outside the domain
+// are never assigned above level 0
+static int Gip_SolverPropagateDomain( Gip_Solver_t * p )
+{
+    Gip_Alloc_t * pA = &p->Cdb.Alloc;
+    while ( p->nPropagated < Vec_IntSize(p->vTrail) )
+    {
+        int Lit = Vec_IntEntry( p->vTrail, p->nPropagated++ );
+        Gip_WVec_t * pWs = &p->pWatchers[Lit];
+        Gip_Wat_t * pDat = pWs->pArray;
+        int wlen = pWs->nSize;
+        int w = 0;
+        p->Stats.nPropagations++;
+        while ( w < wlen )
+        {
+            int blocker = pDat[w].blocker;
+            int cid, * pLits, c0, len, i, v;
+            v = Gip_SolverLitValue( p, blocker );
+            if ( v == GIP_TRUE || !Gip_DomainHas(&p->Domain, Gip_LitVar(blocker)) )
+            {
+                w++;
+                continue;
+            }
+            cid = pDat[w].clause;
+            pLits = Gip_ClaLits( pA, cid );
+            if ( pLits[0] == Gip_LitNot(Lit) )
+            {
+                int t = pLits[0]; pLits[0] = pLits[1]; pLits[1] = t;
+            }
+            c0 = pLits[0];
+            if ( c0 != blocker )
+            {
+                v = Gip_SolverLitValue( p, c0 );
+                if ( v == GIP_TRUE || !Gip_DomainHas(&p->Domain, Gip_LitVar(c0)) )
+                {
+                    pDat[w].blocker = c0;
+                    w++;
+                    continue;
+                }
+            }
+            len = Gip_ClaLen( pA, cid );
+            for ( i = 2; i < len; i++ )
+            {
+                if ( Gip_SolverLitValue(p, pLits[i]) != GIP_FALSE )
+                {
+                    int t = pLits[1]; pLits[1] = pLits[i]; pLits[i] = t;
+                    wlen--;
+                    pDat[w] = pDat[wlen];
+                    Gip_WVecPush( &p->pWatchers[Gip_LitNot(pLits[1])], cid, c0 );
+                    goto next_cls;
+                }
+            }
+            pDat[w].blocker = c0;
+            if ( Gip_SolverLitValue(p, c0) == GIP_FALSE )
+            {
+                pWs->nSize = wlen;
+                return cid;
+            }
+            Gip_SolverAssign( p, c0, cid );
+            w++;
+next_cls:;
+        }
+        pWs->nSize = wlen;
+    }
+    return GIP_CREF_NONE;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Propagates; returns the conflict CRef or GIP_CREF_NONE.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverPropagate( Gip_Solver_t * p )
+{
+    if ( Gip_SolverLevelOf(p) == 0 )
+        return Gip_SolverPropagateFull( p );
+    return Gip_SolverPropagateDomain( p );
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipSearch.c
+++ b/src/proof/pdr/gipsat/gipSearch.c
@@ -87,18 +87,6 @@ static int Gip_SolverSearch( Gip_Solver_t * p, int * pAssump, int nAssump, doubl
             int btl;
             numConflict += 1.0;
             p->Stats.nConflicts++;
-            if ( p->nConfLimit > 0 && p->Stats.nConflicts >= p->nConfCounted + p->nConfLimit )
-            {
-                Gip_SolverBacktrack( p, nAssump, 1 );
-                p->fCanceled = 1;
-                return GIP_UNDEF;
-            }
-            if ( p->TimeLimit && (p->Stats.nConflicts & 1023) == 0 && Abc_Clock() > p->TimeLimit )
-            {
-                Gip_SolverBacktrack( p, nAssump, 1 );
-                p->fCanceled = 1;
-                return GIP_UNDEF;
-            }
             if ( Gip_SolverLevelOf(p) == 0 )
             {
                 Gip_LitSetClear( &p->UnsatCore );
@@ -126,6 +114,13 @@ static int Gip_SolverSearch( Gip_Solver_t * p, int * pAssump, int nAssump, doubl
         }
         else
         {
+            if ( (p->nConfLimit > 0 && p->Stats.nConflicts >= p->nConfCounted + p->nConfLimit) ||
+                 (p->TimeLimit && (p->Stats.nConflicts & 1023) == 0 && Abc_Clock() > p->TimeLimit) )
+            {
+                Gip_SolverBacktrack( p, nAssump, 1 );
+                p->fCanceled = 1;
+                return GIP_UNDEF;
+            }
             if ( noc >= 0 && numConflict >= noc )
             {
                 Gip_SolverBacktrack( p, nAssump, 1 );

--- a/src/proof/pdr/gipsat/gipSearch.c
+++ b/src/proof/pdr/gipsat/gipSearch.c
@@ -1,0 +1,229 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include <math.h>
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+// internal search result: the per-round conflict budget was exhausted
+#define GIP_RESTART (-2)
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+void Gip_SolverAssign( Gip_Solver_t * p, int Lit, int Reason )
+{
+    int Var = Gip_LitVar( Lit );
+    Vec_IntPush( p->vTrail, Lit );
+    Gip_SolverSetLit( p, Lit );
+    p->pReason[Var] = Reason;
+    p->pLevel[Var] = (unsigned)Gip_SolverLevelOf( p );
+}
+
+void Gip_SolverNewLevel( Gip_Solver_t * p )
+{
+    Vec_IntPush( p->vPosInTrail, Vec_IntSize(p->vTrail) );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Backtracks to the given level, saving phases.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverBacktrack( Gip_Solver_t * p, int Level, int fVsids )
+{
+    if ( Gip_SolverLevelOf(p) <= Level )
+        return;
+    while ( Vec_IntSize(p->vTrail) > Vec_IntEntry(p->vPosInTrail, Level) )
+    {
+        int Lit = Vec_IntPop( p->vTrail );
+        int Var = Gip_LitVar( Lit );
+        Gip_SolverSetNone( p, Var );
+        if ( fVsids )
+            Gip_VsidsPush( &p->Vsids, Var );
+        p->pPhase[Var] = (char)(1 ^ Gip_LitCompl(Lit));
+    }
+    p->nPropagated = Vec_IntEntry( p->vPosInTrail, Level );
+    Vec_IntShrink( p->vPosInTrail, Level );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [One restart round of CDCL search.]
+
+  Description [Returns GIP_SAT/GIP_UNSAT when decided, GIP_RESTART when
+  the per-round conflict budget (noc) is exhausted, GIP_UNDEF when a
+  global limit (conflicts/time) canceled the solve.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static int Gip_SolverSearch( Gip_Solver_t * p, int * pAssump, int nAssump, double noc )
+{
+    double numConflict = 0.0;
+    while ( 1 )
+    {
+        int Conflict = Gip_SolverPropagate( p );
+        if ( Conflict != GIP_CREF_NONE )
+        {
+            int btl;
+            numConflict += 1.0;
+            p->Stats.nConflicts++;
+            if ( p->nConfLimit > 0 && p->Stats.nConflicts >= p->nConfCounted + p->nConfLimit )
+            {
+                Gip_SolverBacktrack( p, nAssump, 1 );
+                p->fCanceled = 1;
+                return GIP_UNDEF;
+            }
+            if ( p->TimeLimit && (p->Stats.nConflicts & 1023) == 0 && Abc_Clock() > p->TimeLimit )
+            {
+                Gip_SolverBacktrack( p, nAssump, 1 );
+                p->fCanceled = 1;
+                return GIP_UNDEF;
+            }
+            if ( Gip_SolverLevelOf(p) == 0 )
+            {
+                Gip_LitSetClear( &p->UnsatCore );
+                return GIP_UNSAT;
+            }
+            btl = Gip_SolverAnalyze( p, Conflict, p->vLearntCls );
+            Gip_SolverBacktrack( p, btl, 1 );
+            if ( Vec_IntSize(p->vLearntCls) == 1 )
+            {
+                assert( btl == 0 );
+                Gip_SolverAssign( p, Vec_IntEntry(p->vLearntCls, 0), GIP_CREF_NONE );
+            }
+            else
+            {
+                int Kind = GIP_CLA_LEARNT, i, Lit, Cref;
+                Vec_IntForEachEntry( p->vLearntCls, Lit, i )
+                    if ( Gip_LitVar(Lit) == p->constrainAct )
+                        Kind = GIP_CLA_TEMPORARY;
+                Cref = Gip_SolverAttachClause( p, Vec_IntArray(p->vLearntCls), Vec_IntSize(p->vLearntCls), Kind );
+                Gip_CdbBump( &p->Cdb, Cref );
+                Gip_SolverAssign( p, Gip_ClaLits(&p->Cdb.Alloc, Cref)[0], Cref );
+            }
+            Gip_VsidsDecay( &p->Vsids );
+            Gip_CdbDecay( &p->Cdb );
+        }
+        else
+        {
+            if ( noc >= 0 && numConflict >= noc )
+            {
+                Gip_SolverBacktrack( p, nAssump, 1 );
+                return GIP_RESTART;
+            }
+            Gip_SolverCleanLearnt( p, 0 );
+            // place assumptions one decision level at a time
+            while ( Gip_SolverLevelOf(p) < nAssump )
+            {
+                int a = pAssump[Gip_SolverLevelOf(p)];
+                int v = Gip_SolverLitValue( p, a );
+                if ( v == GIP_TRUE )
+                {
+                    Gip_SolverNewLevel( p );
+                    if ( Gip_SolverLevelOf(p) == nAssump )
+                        Gip_SolverPrepareVsids( p );
+                }
+                else if ( v == GIP_FALSE )
+                {
+                    Gip_SolverAnalyzeUnsatCore( p, a );
+                    return GIP_UNSAT;
+                }
+                else
+                {
+                    Gip_SolverNewLevel( p );
+                    Gip_SolverAssign( p, a, GIP_CREF_NONE );
+                    if ( Gip_SolverLevelOf(p) == nAssump )
+                        Gip_SolverPrepareVsids( p );
+                    goto continue_main;
+                }
+            }
+            if ( !Gip_SolverDecide( p ) )
+                return GIP_SAT;
+        }
+continue_main:;
+    }
+}
+
+static double Gip_Luby( double y, unsigned x )
+{
+    unsigned size = 1, seq = 0;
+    while ( size < x + 1 )
+    {
+        seq++;
+        size = 2 * size + 1;
+    }
+    while ( size - 1 != x )
+    {
+        size = (size - 1) >> 1;
+        seq--;
+        x %= size;
+    }
+    return pow( y, (double)seq );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Search with luby restarts.]
+
+  Description [nRestartLimit < 0 means unlimited. After 10 restarts,
+  switches from the approximate bucket to the exact activity heap.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverSearchWithRestart( Gip_Solver_t * p, int * pAssump, int nAssump, int nRestartLimit )
+{
+    unsigned restarts = 0;
+    while ( 1 )
+    {
+        double restBase;
+        int res;
+        if ( nRestartLimit >= 0 && restarts >= (unsigned)nRestartLimit )
+            return GIP_UNDEF;
+        if ( restarts > 10 && p->Vsids.fEnableBucket )
+        {
+            int i, d;
+            p->Vsids.fEnableBucket = 0;
+            Gip_HeapClear( &p->Vsids.Heap );
+            Vec_IntForEachEntry( p->Domain.Set.vSet, d, i )
+                if ( p->pValue[d] == GIP_NONE )
+                    Gip_VsidsPush( &p->Vsids, d );
+        }
+        restBase = Gip_Luby( 2.0, restarts );
+        res = Gip_SolverSearch( p, pAssump, nAssump, restBase * 100.0 );
+        if ( res == GIP_RESTART )
+        {
+            restarts++;
+            continue;
+        }
+        return res;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipSimp.c
+++ b/src/proof/pdr/gipsat/gipSimp.c
@@ -1,0 +1,339 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+// clauses longer than this many literals do not participate in subsumption
+#define GIP_SUBSUME_MAX_LEN  100
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+// in-place literal removal from a clause (non-watched position only)
+static void Gip_ClaSwapRemoveLit( Gip_Alloc_t * pA, int Cref, int j )
+{
+    int * pLits = Gip_ClaLits( pA, Cref );
+    int nLits = Gip_ClaLen( pA, Cref );
+    assert( j > 1 && nLits > 2 );
+    pLits[j] = pLits[nLits-1];
+    if ( Gip_ClaIsLearnt(pA, Cref) )
+        pA->pData[Cref + nLits] = pA->pData[Cref + nLits + 1];
+    Gip_ClaSetLen( pA, Cref, nLits - 1 );
+}
+
+// removes satisfied clauses; strips false literals
+static void Gip_SolverSimplifySatisfiedList( Gip_Solver_t * p, Vec_Int_t * vClauses )
+{
+    int i = 0;
+    while ( i < Vec_IntSize(vClauses) )
+    {
+        int Cref = Vec_IntEntry( vClauses, i );
+        int j = 0, fRemoved = 0;
+        while ( j < Gip_ClaLen(&p->Cdb.Alloc, Cref) )
+        {
+            int Lit = Gip_ClaLits( &p->Cdb.Alloc, Cref )[j];
+            int v = Gip_SolverLitValue( p, Lit );
+            if ( v == GIP_TRUE )
+            {
+                Vec_IntWriteEntry( vClauses, i, Vec_IntEntryLast(vClauses) );
+                Vec_IntPop( vClauses );
+                Gip_SolverDetachClause( p, Cref );
+                fRemoved = 1;
+                break;
+            }
+            if ( v == GIP_FALSE )
+            {
+                if ( j <= 1 )
+                {
+                    // a watched literal is false at level 0; BCP invariant
+                    // guarantees the clause is satisfied -- drop it
+                    Vec_IntWriteEntry( vClauses, i, Vec_IntEntryLast(vClauses) );
+                    Vec_IntPop( vClauses );
+                    Gip_SolverDetachClause( p, Cref );
+                    fRemoved = 1;
+                    break;
+                }
+                Gip_ClaSwapRemoveLit( &p->Cdb.Alloc, Cref, j );
+            }
+            else
+                j++;
+        }
+        if ( !fRemoved )
+            i++;
+    }
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Removes clauses satisfied at level 0 from all lists.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static void Gip_SolverSimplifySatisfied( Gip_Solver_t * p )
+{
+    assert( Gip_SolverLevelOf(p) == 0 );
+    if ( p->nLastNumAssign >= Vec_IntSize(p->vTrail) )
+        return;
+    Gip_SolverSimplifySatisfiedList( p, p->Cdb.vLemmas );
+    Gip_SolverSimplifySatisfiedList( p, p->Cdb.vLearnt );
+    Gip_SolverSimplifySatisfiedList( p, p->Cdb.vTrans );
+    p->nLastNumAssign = Vec_IntSize( p->vTrail );
+}
+
+typedef struct Gip_SubEnt_t_
+{
+    int          Cref;
+    Vec_Int_t *  vSorted;    // literals sorted ascending
+} Gip_SubEnt_t;
+
+// stable counting sort by clause length (lengths are 2..GIP_SUBSUME_MAX_LEN);
+// ties keep insertion order, so the result is machine-independent
+static void Gip_SubEntSortByLen( Gip_SubEnt_t * pEnts, int nEnts )
+{
+    int pOffset[GIP_SUBSUME_MAX_LEN + 2] = {0};
+    Gip_SubEnt_t * pTmp;
+    int i, len, sum = 0;
+    for ( i = 0; i < nEnts; i++ )
+    {
+        len = Vec_IntSize( pEnts[i].vSorted );
+        assert( len >= 0 && len <= GIP_SUBSUME_MAX_LEN );
+        pOffset[len]++;
+    }
+    for ( i = 0; i <= GIP_SUBSUME_MAX_LEN + 1; i++ )
+    {
+        int c = pOffset[i];
+        pOffset[i] = sum;
+        sum += c;
+    }
+    pTmp = ABC_ALLOC( Gip_SubEnt_t, nEnts );
+    for ( i = 0; i < nEnts; i++ )
+        pTmp[ pOffset[Vec_IntSize(pEnts[i].vSorted)]++ ] = pEnts[i];
+    memcpy( pEnts, pTmp, sizeof(Gip_SubEnt_t) * nEnts );
+    ABC_FREE( pTmp );
+}
+
+// returns 1 (full subsume) with *pDiff = -1, or 0 with *pDiff = the single
+// literal l of vSelf whose negation appears in vOther (self-subsumption
+// candidate), or 0 with *pDiff = -1 (no relation). Both inputs sorted,
+// one literal per variable.
+static int Gip_SubsumeExceptOne( Vec_Int_t * vSelf, Vec_Int_t * vOther, int * pDiff )
+{
+    int i = 0, j = 0, nDiff = 0;
+    *pDiff = -1;
+    if ( Vec_IntSize(vSelf) > Vec_IntSize(vOther) )
+        return 0;
+    while ( i < Vec_IntSize(vSelf) )
+    {
+        int a, b;
+        if ( j >= Vec_IntSize(vOther) )
+            { *pDiff = -1; return 0; }
+        a = Vec_IntEntry( vSelf, i );
+        b = Vec_IntEntry( vOther, j );
+        if ( Gip_LitVar(a) == Gip_LitVar(b) )
+        {
+            if ( a != b )
+            {
+                if ( ++nDiff > 1 )
+                    { *pDiff = -1; return 0; }
+                *pDiff = a;
+            }
+            i++; j++;
+        }
+        else if ( Gip_LitVar(b) < Gip_LitVar(a) )
+            j++;
+        else
+            { *pDiff = -1; return 0; }
+    }
+    if ( nDiff == 0 )
+        { *pDiff = -1; return 1; }
+    return 0;
+}
+
+static void Gip_SubEntRefresh( Gip_Solver_t * p, Gip_SubEnt_t * pEnt )
+{
+    int * pLits = Gip_ClaLits( &p->Cdb.Alloc, pEnt->Cref );
+    int nLits = Gip_ClaLen( &p->Cdb.Alloc, pEnt->Cref );
+    int i;
+    Vec_IntClear( pEnt->vSorted );
+    for ( i = 0; i < nLits; i++ )
+        Vec_IntPush( pEnt->vSorted, pLits[i] );
+    Vec_IntSort( pEnt->vSorted, 0 );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Forward subsumption + self-subsumption over the lemma list.]
+
+  Description [Overlong clauses are excluded from subsumption but kept
+  in the lemma list. The lemma list is rewritten in place.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static void Gip_SolverSimplifySubsume( Gip_Solver_t * p )
+{
+    Vec_Int_t * vLemmas = p->Cdb.vLemmas;
+    int nEnts = 0, i, j, Cref;
+    Gip_SubEnt_t * pEnts;
+    Vec_Ptr_t * vOccurs;    // per var: Vec_Int_t* of entry indices (lazy)
+    if ( Vec_IntSize(vLemmas) == 0 )
+        return;
+    pEnts = ABC_ALLOC( Gip_SubEnt_t, Vec_IntSize(vLemmas) );
+    Vec_IntForEachEntry( vLemmas, Cref, i )
+    {
+        if ( Gip_ClaLen(&p->Cdb.Alloc, Cref) > GIP_SUBSUME_MAX_LEN )
+            continue;
+        pEnts[nEnts].Cref = Cref;
+        pEnts[nEnts].vSorted = Vec_IntAlloc( Gip_ClaLen(&p->Cdb.Alloc, Cref) );
+        Gip_SubEntRefresh( p, &pEnts[nEnts] );
+        nEnts++;
+    }
+    Gip_SubEntSortByLen( pEnts, nEnts );
+    // occurs table over entry indices
+    vOccurs = Vec_PtrStart( p->nVarsAlloc );
+    for ( i = 0; i < nEnts; i++ )
+    {
+        int Lit;
+        Vec_IntForEachEntry( pEnts[i].vSorted, Lit, j )
+        {
+            Vec_Int_t * vO = (Vec_Int_t *)Vec_PtrEntry( vOccurs, Gip_LitVar(Lit) );
+            if ( vO == NULL )
+            {
+                vO = Vec_IntAlloc( 8 );
+                Vec_PtrWriteEntry( vOccurs, Gip_LitVar(Lit), vO );
+            }
+            Vec_IntPush( vO, i );
+        }
+    }
+    for ( i = 0; i < nEnts; i++ )
+    {
+        int bestLit = -1, bestOcc = ABC_INFINITY, Lit, sub, k;
+        Vec_Int_t * vCand;
+        if ( Gip_ClaIsRemoved(&p->Cdb.Alloc, pEnts[i].Cref) )
+            continue;
+        // pick the literal with the fewest occurrences
+        Vec_IntForEachEntry( pEnts[i].vSorted, Lit, j )
+        {
+            Vec_Int_t * vO = (Vec_Int_t *)Vec_PtrEntry( vOccurs, Gip_LitVar(Lit) );
+            int nOcc = vO ? Vec_IntSize(vO) : 0;
+            if ( nOcc < bestOcc )
+            {
+                bestOcc = nOcc;
+                bestLit = Lit;
+            }
+        }
+        vCand = (Vec_Int_t *)Vec_PtrEntry( vOccurs, Gip_LitVar(bestLit) );
+        if ( vCand == NULL )
+            continue;
+        Vec_IntForEachEntry( vCand, sub, k )
+        {
+            int diff, res;
+            if ( sub == i )
+                continue;
+            if ( Gip_ClaIsRemoved(&p->Cdb.Alloc, pEnts[sub].Cref) )
+                continue;
+            if ( Gip_ClaIsRemoved(&p->Cdb.Alloc, pEnts[i].Cref) )
+                break;
+            res = Gip_SubsumeExceptOne( pEnts[i].vSorted, pEnts[sub].vSorted, &diff );
+            if ( res )
+            {
+                Gip_SolverDetachClause( p, pEnts[sub].Cref );
+                p->Stats.nSubsume++;
+            }
+            else if ( diff != -1 )
+            {
+                p->Stats.nSelfSubsume++;
+                if ( Vec_IntSize(pEnts[i].vSorted) == Vec_IntSize(pEnts[sub].vSorted) )
+                {
+                    if ( Vec_IntSize(pEnts[i].vSorted) > 2 )
+                    {
+                        Gip_SolverDetachClause( p, pEnts[sub].Cref );
+                        Gip_SolverStrengthenClause( p, pEnts[i].Cref, diff );
+                        Gip_SubEntRefresh( p, &pEnts[i] );
+                    }
+                }
+                else
+                {
+                    Gip_SolverStrengthenClause( p, pEnts[sub].Cref, Gip_LitNot(diff) );
+                    Gip_SubEntRefresh( p, &pEnts[sub] );
+                }
+            }
+        }
+    }
+    // rebuild the lemma list: overlong clauses (skipped above) + survivors
+    {
+        Vec_Int_t * vNew = Vec_IntAlloc( Vec_IntSize(vLemmas) );
+        Vec_IntForEachEntry( vLemmas, Cref, i )
+            if ( Gip_ClaLen(&p->Cdb.Alloc, Cref) > GIP_SUBSUME_MAX_LEN && !Gip_ClaIsRemoved(&p->Cdb.Alloc, Cref) )
+                Vec_IntPush( vNew, Cref );
+        for ( i = 0; i < nEnts; i++ )
+            if ( !Gip_ClaIsRemoved(&p->Cdb.Alloc, pEnts[i].Cref) )
+                Vec_IntPush( vNew, pEnts[i].Cref );
+        Vec_IntClear( vLemmas );
+        Vec_IntAppend( vLemmas, vNew );
+        Vec_IntFree( vNew );
+    }
+    for ( i = 0; i < nEnts; i++ )
+        Vec_IntFree( pEnts[i].vSorted );
+    ABC_FREE( pEnts );
+    {
+        Vec_Int_t * vO;
+        Vec_PtrForEachEntry( Vec_Int_t *, vOccurs, vO, i )
+            if ( vO ) Vec_IntFree( vO );
+        Vec_PtrFree( vOccurs );
+    }
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Top-level simplify, throttled by solve count.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_SolverSimplify( Gip_Solver_t * p )
+{
+    abctime clk;
+    assert( Gip_SolverLevelOf(p) == 0 );
+    if ( p->Stats.nSolves <= p->nLastSimplify + 100 )
+        return;
+    clk = Abc_Clock();
+    if ( p->nLastNumAssign < Vec_IntSize(p->vTrail) )
+        Gip_SolverSimplifySatisfied( p );
+    if ( p->nLastNumLemma + 1000 < Vec_IntSize(p->Cdb.vLemmas) )
+    {
+        Gip_SolverSimplifySubsume( p );
+        p->nLastNumLemma = Vec_IntSize( p->Cdb.vLemmas );
+    }
+    Gip_SolverGarbageCollect( p );
+    p->nLastSimplify = p->Stats.nSolves;
+    p->Stats.timeSimplify += Abc_Clock() - clk;
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipVsids.c
+++ b/src/proof/pdr/gipsat/gipVsids.c
@@ -1,0 +1,314 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#include "gipsat.h"
+
+ABC_NAMESPACE_IMPL_START
+
+////////////////////////////////////////////////////////////////////////
+///                     FUNCTION DEFINITIONS                         ///
+////////////////////////////////////////////////////////////////////////
+
+static void Gip_HeapInit( Gip_Heap_t * p, int nVarsAlloc )
+{
+    int i;
+    p->vHeap = Vec_IntAlloc( 100 );
+    p->pPos  = ABC_ALLOC( int, nVarsAlloc );
+    for ( i = 0; i < nVarsAlloc; i++ )
+        p->pPos[i] = -1;
+}
+
+static void Gip_HeapFree( Gip_Heap_t * p )
+{
+    Vec_IntFreeP( &p->vHeap );
+    ABC_FREE( p->pPos );
+}
+
+void Gip_HeapClear( Gip_Heap_t * p )
+{
+    int i, v;
+    Vec_IntForEachEntry( p->vHeap, v, i )
+        p->pPos[v] = -1;
+    Vec_IntClear( p->vHeap );
+}
+
+static void Gip_HeapUp( Gip_Heap_t * p, int Var, Gip_Act_t * pAct )
+{
+    int * pHeap = Vec_IntArray( p->vHeap );
+    int idx = p->pPos[Var], pidx;
+    if ( idx == -1 )
+        return;
+    while ( idx != 0 )
+    {
+        pidx = (idx - 1) >> 1;
+        if ( pAct->pAct[pHeap[pidx]] >= pAct->pAct[Var] )
+            break;
+        pHeap[idx] = pHeap[pidx];
+        p->pPos[pHeap[idx]] = idx;
+        idx = pidx;
+    }
+    pHeap[idx] = Var;
+    p->pPos[Var] = idx;
+}
+
+static void Gip_HeapDown( Gip_Heap_t * p, int idx, Gip_Act_t * pAct )
+{
+    int * pHeap = Vec_IntArray( p->vHeap );
+    int nSize = Vec_IntSize( p->vHeap );
+    int v = pHeap[idx];
+    while ( 1 )
+    {
+        int left = 2*idx + 1, right, child;
+        if ( left >= nSize )
+            break;
+        right = left + 1;
+        child = ( right < nSize && pAct->pAct[pHeap[right]] > pAct->pAct[pHeap[left]] ) ? right : left;
+        if ( pAct->pAct[v] >= pAct->pAct[pHeap[child]] )
+            break;
+        pHeap[idx] = pHeap[child];
+        p->pPos[pHeap[idx]] = idx;
+        idx = child;
+    }
+    pHeap[idx] = v;
+    p->pPos[v] = idx;
+}
+
+static void Gip_HeapPush( Gip_Heap_t * p, int Var, Gip_Act_t * pAct )
+{
+    int idx;
+    if ( p->pPos[Var] != -1 )
+        return;
+    idx = Vec_IntSize( p->vHeap );
+    Vec_IntPush( p->vHeap, Var );
+    p->pPos[Var] = idx;
+    Gip_HeapUp( p, Var, pAct );
+}
+
+static int Gip_HeapPop( Gip_Heap_t * p, Gip_Act_t * pAct )
+{
+    int * pHeap, value;
+    if ( Vec_IntSize(p->vHeap) == 0 )
+        return -1;
+    pHeap = Vec_IntArray( p->vHeap );
+    value = pHeap[0];
+    pHeap[0] = pHeap[Vec_IntSize(p->vHeap) - 1];
+    p->pPos[pHeap[0]] = 0;
+    p->pPos[value] = -1;
+    Vec_IntPop( p->vHeap );
+    if ( Vec_IntSize(p->vHeap) > 1 )
+        Gip_HeapDown( p, 0, pAct );
+    return value;
+}
+
+// number of significant bits of a 64-bit value (0 -> 0)
+static inline int Gip_Bits64( word b )
+{
+    int n = 0;
+    while ( b ) { n++; b >>= 1; }
+    return n;
+}
+
+// bucket-table maintenance on first bump of a var: bucket_table[pos]
+// approximates ceil(log2(pos+1)); one trailing entry (value = last + 1)
+// serves vars that were never bumped
+static void Gip_ActCheck( Gip_Act_t * p, int Var )
+{
+    if ( p->BktHeap.pPos[Var] == -1 )
+    {
+        word b;
+        int blog;
+        Gip_HeapPush( &p->BktHeap, Var, p );
+        b = (word)(Vec_IntSize( p->vBktTable ) - 1);
+        blog = Gip_Bits64( b );
+        Vec_IntWriteEntry( p->vBktTable, Vec_IntSize(p->vBktTable) - 1, blog );
+        Vec_IntPush( p->vBktTable, blog + 1 );
+    }
+    assert( p->BktHeap.pPos[Var] != -1 );
+}
+
+static int Gip_ActBucketOf( Gip_Act_t * p, int Var )
+{
+    int pos = p->BktHeap.pPos[Var];
+    if ( pos == -1 )
+        return Vec_IntEntryLast( p->vBktTable );
+    return Vec_IntEntry( p->vBktTable, pos );
+}
+
+static void Gip_ActBump( Gip_Act_t * p, int Var, int nVarsAlloc )
+{
+    p->pAct[Var] += p->actInc;
+    Gip_ActCheck( p, Var );
+    Gip_HeapUp( &p->BktHeap, Var, p );
+    if ( p->pAct[Var] > 1e100 )
+    {
+        int i;
+        for ( i = 0; i < nVarsAlloc; i++ )
+            p->pAct[i] *= 1e-100;
+        p->actInc *= 1e-100;
+    }
+}
+
+static void Gip_BucketEnsure( Gip_Bucket_t * p, int nBuckets )
+{
+    while ( Vec_PtrSize(p->vBuckets) < nBuckets )
+        Vec_PtrPush( p->vBuckets, Vec_IntAlloc(16) );
+}
+
+static void Gip_BucketPush( Gip_Bucket_t * p, int Var, Gip_Act_t * pAct )
+{
+    int bucket;
+    if ( p->pInBucket[Var] )
+        return;
+    bucket = Gip_ActBucketOf( pAct, Var );
+    if ( p->head > bucket )
+        p->head = bucket;
+    Gip_BucketEnsure( p, bucket + 1 );
+    Vec_IntPush( (Vec_Int_t *)Vec_PtrEntry(p->vBuckets, bucket), Var );
+    p->pInBucket[Var] = 1;
+}
+
+static int Gip_BucketPop( Gip_Bucket_t * p )
+{
+    while ( p->head < Vec_PtrSize(p->vBuckets) )
+    {
+        Vec_Int_t * vB = (Vec_Int_t *)Vec_PtrEntry( p->vBuckets, p->head );
+        if ( Vec_IntSize(vB) > 0 )
+        {
+            int Var = Vec_IntPop( vB );
+            p->pInBucket[Var] = 0;
+            return Var;
+        }
+        p->head++;
+    }
+    return -1;
+}
+
+void Gip_BucketClear( Gip_Bucket_t * p )
+{
+    int i;
+    Vec_Int_t * vB;
+    while ( p->head < Vec_PtrSize(p->vBuckets) )
+    {
+        vB = (Vec_Int_t *)Vec_PtrEntry( p->vBuckets, p->head );
+        while ( Vec_IntSize(vB) > 0 )
+            p->pInBucket[Vec_IntPop(vB)] = 0;
+        p->head++;
+    }
+    Vec_PtrForEachEntry( Vec_Int_t *, p->vBuckets, vB, i )
+        Vec_IntClear( vB );
+    p->head = 0;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Initializes the VSIDS state.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+void Gip_VsidsInit( Gip_Vsids_t * p, int nVarsAlloc )
+{
+    p->Act.pAct = ABC_CALLOC( double, nVarsAlloc );
+    p->Act.actInc = 1.0;
+    Gip_HeapInit( &p->Act.BktHeap, nVarsAlloc );
+    p->Act.vBktTable = Vec_IntAlloc( 100 );
+    Vec_IntPush( p->Act.vBktTable, 0 );
+    Gip_HeapInit( &p->Heap, nVarsAlloc );
+    p->Bucket.vBuckets = Vec_PtrAlloc( 16 );
+    Gip_BucketEnsure( &p->Bucket, 10 );
+    p->Bucket.pInBucket = ABC_CALLOC( char, nVarsAlloc );
+    p->Bucket.head = 0;
+    p->fEnableBucket = 1;
+    p->nVarsAlloc = nVarsAlloc;
+}
+
+void Gip_VsidsFree( Gip_Vsids_t * p )
+{
+    Vec_Int_t * vB;
+    int i;
+    ABC_FREE( p->Act.pAct );
+    Gip_HeapFree( &p->Act.BktHeap );
+    Vec_IntFreeP( &p->Act.vBktTable );
+    Gip_HeapFree( &p->Heap );
+    Vec_PtrForEachEntry( Vec_Int_t *, p->Bucket.vBuckets, vB, i )
+        Vec_IntFree( vB );
+    Vec_PtrFree( p->Bucket.vBuckets );
+    ABC_FREE( p->Bucket.pInBucket );
+}
+
+void Gip_VsidsPush( Gip_Vsids_t * p, int Var )
+{
+    if ( p->fEnableBucket )
+        Gip_BucketPush( &p->Bucket, Var, &p->Act );
+    else
+        Gip_HeapPush( &p->Heap, Var, &p->Act );
+}
+
+static int Gip_VsidsPop( Gip_Vsids_t * p )
+{
+    if ( p->fEnableBucket )
+        return Gip_BucketPop( &p->Bucket );
+    return Gip_HeapPop( &p->Heap, &p->Act );
+}
+
+void Gip_VsidsBump( Gip_Vsids_t * p, int Var )
+{
+    Gip_ActBump( &p->Act, Var, p->nVarsAlloc );
+    if ( !p->fEnableBucket )
+        Gip_HeapUp( &p->Heap, Var, &p->Act );
+    Gip_BucketEnsure( &p->Bucket, Vec_IntEntryLast(p->Act.vBktTable) + 1 );
+}
+
+void Gip_VsidsDecay( Gip_Vsids_t * p )
+{
+    p->Act.actInc *= 1.0 / 0.95;
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Picks and assigns the next decision literal.]
+
+  Description [Assigned vars popped from VSIDS are skipped. The phase of
+  a var seen before is its saved phase; a never-assigned var gets FALSE.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+int Gip_SolverDecide( Gip_Solver_t * p )
+{
+    int decide, Lit;
+    while ( (decide = Gip_VsidsPop(&p->Vsids)) != -1 )
+    {
+        if ( p->pValue[decide] != GIP_NONE )
+            continue;
+        if ( p->pPhase[decide] != GIP_NONE )
+            Lit = Gip_Lit( decide, p->pPhase[decide] == GIP_FALSE );
+        else
+            Lit = Gip_Lit( decide, 1 );
+        Vec_IntPush( p->vPosInTrail, Vec_IntSize(p->vTrail) );
+        Gip_SolverAssign( p, Lit, GIP_CREF_NONE );
+        p->Stats.nDecisions++;
+        return 1;
+    }
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////
+
+ABC_NAMESPACE_IMPL_END

--- a/src/proof/pdr/gipsat/gipsat.h
+++ b/src/proof/pdr/gipsat/gipsat.h
@@ -1,0 +1,349 @@
+/**************************************************************************************************
+GipSAT -- C port of the GipSAT solver from the rIC3 model checker (https://github.com/gipsyh/rIC3),
+ported from rIC3 v1.5.2-60-g4a97bec, src/gipsat/.
+Copyright (C) 2023 - Present, Yuheng Su <gipsyh.icu@gmail.com>. All rights reserved.
+Ported to C for ABC by Wish, 2026.
+
+rIC3 is distributed under the GNU General Public License v3. This port is distributed as part of
+ABC under the ABC license (see copyright.txt in the ABC root) with the explicit permission of the
+rIC3 author.
+**************************************************************************************************/
+
+#ifndef ABC__proof__pdr__gipsat_h
+#define ABC__proof__pdr__gipsat_h
+
+#include "aig/saig/saig.h"
+#include "sat/cnf/cnf.h"
+#include "misc/vec/vec.h"
+
+ABC_NAMESPACE_HEADER_START
+
+////////////////////////////////////////////////////////////////////////
+///                      BASIC TYPES                                 ///
+////////////////////////////////////////////////////////////////////////
+
+// Lbool values (var assignment); lit value = pValue[var] ^ compl(lit)
+#define GIP_FALSE   0
+#define GIP_TRUE    1
+#define GIP_NONE    2
+
+// clause reference: offset into the arena; GIP_CREF_NONE = no clause
+#define GIP_CREF_NONE  (0x7FFFFFFF)
+
+// solve results (match ABC usage: 1 = SAT, 0 = UNSAT, -1 = undecided)
+#define GIP_SAT      1
+#define GIP_UNSAT    0
+#define GIP_UNDEF   (-1)
+
+// clause kinds
+#define GIP_CLA_TRANS      0
+#define GIP_CLA_LEMMA      1
+#define GIP_CLA_LEARNT     2
+#define GIP_CLA_TEMPORARY  3
+
+static inline int Gip_Lit( int Var, int fCompl )  { return 2*Var + (fCompl != 0);  }
+static inline int Gip_LitVar( int Lit )           { return Lit >> 1;               }
+static inline int Gip_LitCompl( int Lit )         { return Lit & 1;                }
+static inline int Gip_LitNot( int Lit )           { return Lit ^ 1;                }
+
+////////////////////////////////////////////////////////////////////////
+///                      SMALL CONTAINERS                            ///
+////////////////////////////////////////////////////////////////////////
+
+typedef struct Gip_Wat_t_
+{
+    int          clause;      // CRef
+    int          blocker;     // Lit
+} Gip_Wat_t;
+
+// per-literal watcher list
+typedef struct Gip_WVec_t_
+{
+    Gip_Wat_t *  pArray;
+    int          nSize;
+    int          nCap;
+} Gip_WVec_t;
+
+// insertion-ordered var set with membership flags
+typedef struct Gip_VarSet_t_
+{
+    Vec_Int_t *  vSet;
+    char *       pHas;        // indexed by var
+} Gip_VarSet_t;
+
+typedef struct Gip_LitSet_t_
+{
+    Vec_Int_t *  vSet;
+    char *       pHas;        // indexed by lit
+} Gip_LitSet_t;
+
+typedef struct Gip_Domain_t_
+{
+    Gip_VarSet_t Set;
+    int          nFixed;
+} Gip_Domain_t;
+
+////////////////////////////////////////////////////////////////////////
+///                      CLAUSE DATABASE                             ///
+////////////////////////////////////////////////////////////////////////
+
+// arena allocator; one clause = [header][lits...][act(f32) if learnt]
+// header bits: 0 trans, 1 learnt, 2 reloced, 3 marked, 4 removed, 5..31 len
+typedef struct Gip_Alloc_t_
+{
+    unsigned *   pData;
+    unsigned     nSize;       // words used
+    unsigned     nCap;        // words allocated
+    unsigned     nWasted;     // words freed
+} Gip_Alloc_t;
+
+typedef struct Gip_Cdb_t_
+{
+    Gip_Alloc_t  Alloc;
+    Vec_Int_t *  vTrans;      // CRefs of transition clauses
+    Vec_Int_t *  vLemmas;     // CRefs of lemma clauses
+    Vec_Int_t *  vLearnt;     // CRefs of learnt clauses
+    Vec_Int_t *  vTemp;       // CRefs of temporary clauses
+    float        actInc;      // clause activity increment (init 1.0)
+} Gip_Cdb_t;
+
+////////////////////////////////////////////////////////////////////////
+///                      VSIDS                                       ///
+////////////////////////////////////////////////////////////////////////
+
+// binary max-heap keyed by activity
+typedef struct Gip_Heap_t_
+{
+    Vec_Int_t *  vHeap;       // vars
+    int *        pPos;        // var -> index in vHeap, -1 if absent
+} Gip_Heap_t;
+
+// activity values + log-scale bucket table
+typedef struct Gip_Act_t_
+{
+    double *     pAct;        // per var
+    double       actInc;      // init 1.0
+    Gip_Heap_t   BktHeap;     // heap of all ever-bumped vars, ordered by act
+    Vec_Int_t *  vBktTable;   // bucket_table (init: one entry 0)
+} Gip_Act_t;
+
+typedef struct Gip_Bucket_t_
+{
+    Vec_Ptr_t *  vBuckets;    // of Vec_Int_t* (bucket idx -> stack of vars)
+    char *       pInBucket;   // per var
+    int          head;
+} Gip_Bucket_t;
+
+typedef struct Gip_Vsids_t_
+{
+    Gip_Act_t    Act;
+    Gip_Heap_t   Heap;        // exact mode
+    Gip_Bucket_t Bucket;      // approximate mode
+    int          fEnableBucket; // default 1
+    int          nVarsAlloc;  // for activity rescaling
+} Gip_Vsids_t;
+
+////////////////////////////////////////////////////////////////////////
+///                      STATIC CONTEXT (shared by all frames)       ///
+////////////////////////////////////////////////////////////////////////
+
+// Built once from the static CNF of the entire AIG. Cnf_ManWriteCnfOther
+// emits literals as 2*ObjId(+1), so solver var == Aig object id and
+// nVars == Aig_ManObjNumMax. Never mutated.
+#define Gip_ObjVar( pObj )  Aig_ObjId(pObj)
+typedef struct Gip_Ctx_t_
+{
+    Aig_Man_t *  pAig;        // not owned
+    Cnf_Dat_t *  pCnf;        // owned by this ctx
+    int          nVars;       // pCnf->nVars
+    int          varConst;    // var of Aig const1
+    // dep table in CSR form: dep(v) = pDepData[pDepOffset[v] .. pDepOffset[v+1])
+    int *        pDepOffset;  // size nVars+1
+    int *        pDepData;
+    int          nDepData;
+} Gip_Ctx_t;
+
+////////////////////////////////////////////////////////////////////////
+///                      SOLVER                                      ///
+////////////////////////////////////////////////////////////////////////
+
+typedef struct Gip_Stats_t_
+{
+    ABC_INT64_T  nSolves;
+    ABC_INT64_T  nConflicts;
+    ABC_INT64_T  nDecisions;
+    ABC_INT64_T  nPropagations;
+    ABC_INT64_T  nSubsume;
+    ABC_INT64_T  nSelfSubsume;
+    abctime      timeSolve;
+    abctime      timeSimplify;   // inside timeSolve: full simplify passes
+    abctime      timeCleanL;     // inside timeSolve: CleanLearnt sort+rebuild
+} Gip_Stats_t;
+
+typedef struct Gip_Solver_t_
+{
+    Gip_Ctx_t *  pCtx;            // shared, read-only
+    // variable space: vars 0..nVars-1 are CNF vars; constrainAct == nVars;
+    // all per-var arrays are sized nVarsAlloc >= nVars+1
+    int          nVars;
+    int          nVarsAlloc;
+    int          constrainAct;
+    // core CDCL state
+    Gip_Cdb_t    Cdb;
+    Gip_WVec_t * pWatchers;       // per lit (2*nVarsAlloc)
+    char *       pValue;          // per var: GIP_FALSE/TRUE/NONE
+    Vec_Int_t *  vTrail;          // lits
+    Vec_Int_t *  vPosInTrail;     // trail start index per decision level
+    unsigned *   pLevel;          // per var
+    int *        pReason;         // per var: CRef
+    int          nPropagated;
+    Gip_Vsids_t  Vsids;
+    char *       pPhase;          // per var: saved phase (Lbool)
+    // analyze
+    char *       pMark;           // per var: 0 unseen, 1 seen, 2 removable, 3 failed
+    Vec_Int_t *  vClear;          // lits to clear
+    Vec_Int_t *  vAnaStack;       // scratch for lit_redundant (pairs)
+    Vec_Int_t *  vLearntCls;      // scratch learnt clause
+    // unsat core
+    Gip_LitSet_t UnsatCore;
+    // domain
+    Gip_Domain_t Domain;
+    int          fTempDomain;
+    int          fPreparedVsids;
+    // simplify state
+    int          nLastNumAssign;
+    ABC_INT64_T  nLastSimplify;
+    int          nLastNumLemma;   // init 1000
+    // status
+    int          fTrivialUnsat;
+    // limits for the current solve
+    ABC_INT64_T  nConfLimit;      // 0 = none; per solve call
+    ABC_INT64_T  nConfCounted;    // Stats.nConflicts at solve start
+    abctime      TimeLimit;       // 0 = none; absolute deadline
+    int          fCanceled;       // set when limit hit
+    // scratch
+    Vec_Int_t *  vSimpCls;        // simplify_clause output
+    Vec_Int_t *  vSeeds;          // domain seeds scratch
+    Vec_Int_t *  vAssump;         // current assumption (with constrainAct lit)
+    Gip_Stats_t  Stats;
+} Gip_Solver_t;
+
+////////////////////////////////////////////////////////////////////////
+///                      API                                         ///
+////////////////////////////////////////////////////////////////////////
+
+// gipMan.c
+extern Gip_Ctx_t *    Gip_CtxCreate( Aig_Man_t * pAig, Cnf_Man_t * pCnfMan );
+extern void           Gip_CtxFree( Gip_Ctx_t * p );
+
+// gipMain.c
+extern Gip_Solver_t * Gip_SolverNew( Gip_Ctx_t * pCtx );
+extern void           Gip_SolverFree( Gip_Solver_t * p );
+// add a lemma clause: resets the solver, extends the fixed domain
+extern void           Gip_SolverAddLemma( Gip_Solver_t * p, int * pLits, int nLits );
+// full query entry. ppCstCls/pnCstLits: nCst constraint clauses; pass
+// nCst = 0 for none. nRestartLimit < 0 means no restart limit.
+extern int            Gip_SolverSolve( Gip_Solver_t * p,
+                                       int * pAssump, int nAssump,
+                                       int ** ppCstCls, int * pnCstLits, int nCst,
+                                       int nRestartLimit );
+extern int            Gip_SolverVarValue( Gip_Solver_t * p, int Var );   // GIP_NONE -> 0
+extern int            Gip_SolverUnsatHas( Gip_Solver_t * p, int Lit );
+// MIC temporary domain
+extern void           Gip_SolverSetDomain( Gip_Solver_t * p, int * pLits, int nLits );
+extern void           Gip_SolverUnsetDomain( Gip_Solver_t * p );
+// internals shared between gip*.c
+extern void           Gip_SolverReset( Gip_Solver_t * p );
+extern int            Gip_SolverAddClauseInner( Gip_Solver_t * p, int * pLits, int nLits, int Kind );
+
+// gipCdb.c
+extern void           Gip_CdbInit( Gip_Cdb_t * p );
+extern void           Gip_CdbFree( Gip_Cdb_t * p );
+extern void           Gip_CdbBump( Gip_Cdb_t * p, int Cref );
+extern void           Gip_CdbDecay( Gip_Cdb_t * p );
+extern int            Gip_SolverAttachClause( Gip_Solver_t * p, int * pLits, int nLits, int Kind );
+extern void           Gip_SolverDetachClause( Gip_Solver_t * p, int Cref );
+extern void           Gip_SolverCleanTemporary( Gip_Solver_t * p );
+extern void           Gip_SolverCleanLearnt( Gip_Solver_t * p, int fFull );
+extern void           Gip_SolverStrengthenClause( Gip_Solver_t * p, int Cref, int Lit );
+extern void           Gip_SolverGarbageCollect( Gip_Solver_t * p );
+
+// clause accessors (arena layout)
+static inline int        Gip_ClaLen( Gip_Alloc_t * p, int Cref )          { return (int)(p->pData[Cref] >> 5);            }
+static inline int        Gip_ClaIsTrans( Gip_Alloc_t * p, int Cref )      { return (int)(p->pData[Cref] & 1);             }
+static inline int        Gip_ClaIsLearnt( Gip_Alloc_t * p, int Cref )     { return (int)((p->pData[Cref] >> 1) & 1);      }
+static inline int        Gip_ClaIsReloced( Gip_Alloc_t * p, int Cref )    { return (int)((p->pData[Cref] >> 2) & 1);      }
+static inline int        Gip_ClaIsRemoved( Gip_Alloc_t * p, int Cref )    { return (int)((p->pData[Cref] >> 4) & 1);      }
+static inline void       Gip_ClaSetRemoved( Gip_Alloc_t * p, int Cref )   { p->pData[Cref] |= (1u << 4);                  }
+static inline void       Gip_ClaSetReloced( Gip_Alloc_t * p, int Cref )   { p->pData[Cref] |= (1u << 2);                  }
+static inline void       Gip_ClaSetLen( Gip_Alloc_t * p, int Cref, int n ){ p->pData[Cref] = (p->pData[Cref] & 31u) | (((unsigned)n) << 5); }
+static inline int *      Gip_ClaLits( Gip_Alloc_t * p, int Cref )         { return (int *)(p->pData + Cref + 1);          }
+static inline float      Gip_ClaAct( Gip_Alloc_t * p, int Cref )          { float f; memcpy( &f, p->pData + Cref + 1 + Gip_ClaLen(p, Cref), 4 ); return f; }
+static inline void       Gip_ClaSetAct( Gip_Alloc_t * p, int Cref, float f ) { memcpy( p->pData + Cref + 1 + Gip_ClaLen(p, Cref), &f, 4 ); }
+
+// gipProp.c
+extern void           Gip_WatchersAttach( Gip_Solver_t * p, int Cref );
+extern void           Gip_WatchersDetach( Gip_Solver_t * p, int Cref );
+extern int            Gip_SolverPropagate( Gip_Solver_t * p );        // returns conflict CRef or GIP_CREF_NONE
+
+// gipAnalyze.c
+extern int            Gip_SolverAnalyze( Gip_Solver_t * p, int Conflict, Vec_Int_t * vLearnt ); // returns backtrack level; learnt in vLearnt
+extern void           Gip_SolverAnalyzeUnsatCore( Gip_Solver_t * p, int Lit );
+
+// gipSearch.c
+extern void           Gip_SolverAssign( Gip_Solver_t * p, int Lit, int Reason );
+extern void           Gip_SolverNewLevel( Gip_Solver_t * p );
+extern void           Gip_SolverBacktrack( Gip_Solver_t * p, int Level, int fVsids );
+extern int            Gip_SolverSearchWithRestart( Gip_Solver_t * p, int * pAssump, int nAssump, int nRestartLimit );
+
+// gipVsids.c
+extern void           Gip_HeapClear( Gip_Heap_t * p );
+extern void           Gip_VsidsInit( Gip_Vsids_t * p, int nVarsAlloc );
+extern void           Gip_VsidsFree( Gip_Vsids_t * p );
+extern void           Gip_VsidsPush( Gip_Vsids_t * p, int Var );
+extern void           Gip_VsidsBump( Gip_Vsids_t * p, int Var );
+extern void           Gip_VsidsDecay( Gip_Vsids_t * p );
+extern void           Gip_BucketClear( Gip_Bucket_t * p );
+extern int            Gip_SolverDecide( Gip_Solver_t * p );
+
+// gipDomain.c
+extern void           Gip_DomainInit( Gip_Domain_t * p, int nVarsAlloc, int varConst );
+extern void           Gip_DomainFree( Gip_Domain_t * p );
+extern void           Gip_DomainReset( Gip_Domain_t * p );
+extern int            Gip_DomainHas( Gip_Domain_t * p, int Var );
+extern void           Gip_DomainInsert( Gip_Domain_t * p, int Var );
+extern void           Gip_DomainEnableLocal( Gip_Solver_t * p, Vec_Int_t * vSeeds ); // BFS closure over ctx dep
+extern void           Gip_SolverAddDomain( Gip_Solver_t * p, int Var, int fDeps );   // permanent (fixed prefix)
+extern void           Gip_SolverPrepareVsids( Gip_Solver_t * p );
+
+// gipSimp.c
+extern void           Gip_SolverSimplify( Gip_Solver_t * p );
+
+// var/lit-set helpers
+extern void           Gip_VarSetInit( Gip_VarSet_t * p, int nVarsAlloc );
+extern void           Gip_VarSetFree( Gip_VarSet_t * p );
+extern void           Gip_LitSetInit( Gip_LitSet_t * p, int nVarsAlloc );
+extern void           Gip_LitSetFree( Gip_LitSet_t * p );
+static inline int     Gip_VarSetHas( Gip_VarSet_t * p, int Var )  { return p->pHas[Var];  }
+static inline void    Gip_VarSetInsert( Gip_VarSet_t * p, int Var ) { if ( !p->pHas[Var] ) { p->pHas[Var] = 1; Vec_IntPush(p->vSet, Var); } }
+static inline int     Gip_LitSetHas( Gip_LitSet_t * p, int Lit )  { return p->pHas[Lit];  }
+static inline void    Gip_LitSetInsert( Gip_LitSet_t * p, int Lit ) { if ( !p->pHas[Lit] ) { p->pHas[Lit] = 1; Vec_IntPush(p->vSet, Lit); } }
+static inline void    Gip_LitSetClear( Gip_LitSet_t * p ) { int i, l; Vec_IntForEachEntry(p->vSet, l, i) p->pHas[l] = 0; Vec_IntClear(p->vSet); }
+
+// solver small helpers
+static inline int     Gip_SolverLitValue( Gip_Solver_t * p, int Lit )
+{
+    char v = p->pValue[Gip_LitVar(Lit)];
+    return v == GIP_NONE ? GIP_NONE : (v ^ Gip_LitCompl(Lit));
+}
+static inline void    Gip_SolverSetLit( Gip_Solver_t * p, int Lit )   { p->pValue[Gip_LitVar(Lit)] = (char)(1 ^ Gip_LitCompl(Lit)); }
+static inline void    Gip_SolverSetNone( Gip_Solver_t * p, int Var )  { p->pValue[Var] = GIP_NONE; }
+static inline int     Gip_SolverLevelOf( Gip_Solver_t * p )           { return Vec_IntSize(p->vPosInTrail); }
+
+ABC_NAMESPACE_HEADER_END
+
+#endif
+
+////////////////////////////////////////////////////////////////////////
+///                       END OF FILE                                ///
+////////////////////////////////////////////////////////////////////////

--- a/src/proof/pdr/module.make
+++ b/src/proof/pdr/module.make
@@ -1,4 +1,13 @@
-SRC +=    src/proof/pdr/pdrCnf.c \
+SRC +=    src/proof/pdr/gipsat/gipMan.c \
+    src/proof/pdr/gipsat/gipMain.c \
+    src/proof/pdr/gipsat/gipCdb.c \
+    src/proof/pdr/gipsat/gipProp.c \
+    src/proof/pdr/gipsat/gipAnalyze.c \
+    src/proof/pdr/gipsat/gipSearch.c \
+    src/proof/pdr/gipsat/gipVsids.c \
+    src/proof/pdr/gipsat/gipDomain.c \
+    src/proof/pdr/gipsat/gipSimp.c \
+    src/proof/pdr/pdrCnf.c \
     src/proof/pdr/pdrCore.c \
     src/proof/pdr/pdrIncr.c \
     src/proof/pdr/pdrInv.c \

--- a/src/proof/pdr/pdr.h
+++ b/src/proof/pdr/pdr.h
@@ -66,6 +66,7 @@ struct Pdr_Par_t_
     int fCtgs;            // handle CTGs in down
     int fUseAbs;          // use abstraction 
     int fUseSimpleRef;    // simplified CEX refinement
+    int fUseGipSat;       // use GipSAT (IC3-specialized CDCL solver ported from rIC3)
     int fVerbose;         // verbose output`
     int fVeryVerbose;     // very verbose output
     int fNotVerbose;      // not printing line by line progress

--- a/src/proof/pdr/pdrCore.c
+++ b/src/proof/pdr/pdrCore.c
@@ -72,6 +72,7 @@ void Pdr_ManSetDefaultParams( Pdr_Par_t * pPars )
     pPars->fCtgs          =       0;  // handle CTGs in down
     pPars->fUseAbs        =       0;  // use abstraction 
     pPars->fUseSimpleRef  =       0;  // simplified CEX refinement
+    pPars->fUseGipSat     =       0;  // use GipSAT solver (rIC3 port)
     pPars->fVerbose       =       0;  // verbose output
     pPars->fVeryVerbose   =       0;  // very verbose output
     pPars->fNotVerbose    =       0;  // not printing line-by-line progress
@@ -87,10 +88,39 @@ void Pdr_ManSetDefaultParams( Pdr_Par_t * pPars )
 
 /**Function*************************************************************
 
+  Synopsis    [Fixes/releases a temporary GipSAT domain for the MIC loop.]
+
+  Description [During generalization the domain is fixed once from the
+  initial cube (current-state and next-state literals) and reused for
+  all literal-removal queries.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+static void Pdr_ManGipSetMicDomain( Pdr_Man_t * p, int k, Pdr_Set_t * pCube )
+{
+    if ( !p->pPars->fUseGipSat )
+        return;
+    Pdr_ManGipCubeToLits( p, pCube, 0, 0, p->vGipLits );   // current state
+    Pdr_ManGipCubeToLits( p, pCube, 0, 1, p->vLits );      // next state
+    Vec_IntAppend( p->vGipLits, p->vLits );
+    Gip_SolverSetDomain( Pdr_ManGipSolver(p, k), Vec_IntArray(p->vGipLits), Vec_IntSize(p->vGipLits) );
+}
+static void Pdr_ManGipUnsetMicDomain( Pdr_Man_t * p, int k )
+{
+    if ( !p->pPars->fUseGipSat )
+        return;
+    Gip_SolverUnsetDomain( Pdr_ManGipSolver(p, k) );
+}
+
+/**Function*************************************************************
+
   Synopsis    [Reduces clause using analyzeFinal.]
 
   Description [Assumes that the SAT solver just terminated an UNSAT call.]
-               
+
   SideEffects []
 
   SeeAlso     []
@@ -101,10 +131,34 @@ Pdr_Set_t * Pdr_ManReduceClause( Pdr_Man_t * p, int k, Pdr_Set_t * pCube )
     Pdr_Set_t * pCubeMin;
     Vec_Int_t * vLits;
     int i, Entry, nCoreLits, * pCoreLits;
-    // get relevant SAT literals
-    nCoreLits = sat_solver_final(Pdr_ManSolver(p, k), &pCoreLits);
-    // translate them into register literals and remove auxiliary
-    vLits = Pdr_ManLitsToCube( p, k, pCoreLits, nCoreLits );
+    if ( p->pPars->fUseGipSat )
+    {
+        // keep the cube literals whose next-state assumption literal is
+        // in the unsat core
+        Gip_Solver_t * pGip = Pdr_ManGipSolver( p, k );
+        Aig_Obj_t * pObj;
+        int iVar, Lit;
+        Vec_IntClear( p->vLits );
+        for ( i = 0; i < pCube->nLits; i++ )
+        {
+            Lit = pCube->Lits[i];
+            if ( Lit == -1 )
+                continue;
+            pObj = Saig_ManLi( p->pAig, Abc_Lit2Var(Lit) );
+            iVar = Gip_ObjVar( pObj );
+            assert( iVar >= 0 );
+            if ( Gip_SolverUnsatHas( pGip, Abc_Var2Lit(iVar, Abc_LitIsCompl(Lit)) ) )
+                Vec_IntPush( p->vLits, Lit );
+        }
+        vLits = p->vLits;
+    }
+    else
+    {
+        // get relevant SAT literals
+        nCoreLits = sat_solver_final(Pdr_ManSolver(p, k), &pCoreLits);
+        // translate them into register literals and remove auxiliary
+        vLits = Pdr_ManLitsToCube( p, k, pCoreLits, nCoreLits );
+    }
     // skip if there is no improvement
     if ( Vec_IntSize(vLits) == pCube->nLits )
         return NULL;
@@ -192,6 +246,14 @@ int Pdr_ManPushClauses( Pdr_Man_t * p )
 //                Abc_Print( 1, "%d ", pCubeK->nLits - pCubeMin->nLits );
                     Pdr_SetDeref( pCubeK );
                     pCubeK = pCubeMin;
+                    // the reduced clause is stronger than the one the lower
+                    // solvers hold; baseline solvers re-sync with vClauses on
+                    // recycle, but GipSAT solvers are persistent and never
+                    // recycle, so add it to solvers 1..k eagerly (a clause of
+                    // frame k+1 belongs to every frame j <= k+1)
+                    if ( p->pPars->fUseGipSat )
+                        for ( i = 1; i <= k; i++ )
+                            Pdr_ManSolverAddClause( p, i, pCubeK );
                 }
             }
 
@@ -325,6 +387,11 @@ int Pdr_ManPushAndBlockClauses( Pdr_Man_t * p )
 //                Abc_Print( 1, "%d ", pCubeK->nLits - pCubeMin->nLits );
                     Pdr_SetDeref( pCubeK );
                     pCubeK = pCubeMin;
+                    // see Pdr_ManPushClauses: keep persistent GipSAT solvers
+                    // in sync with the strengthened clause
+                    if ( p->pPars->fUseGipSat )
+                        for ( l = 1; l <= k; l++ )
+                            Pdr_ManSolverAddClause( p, l, pCubeK );
                 }
             }
 
@@ -1103,6 +1170,8 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
 
         // sort literals by their occurences
         pOrder = Pdr_ManSortByPriority( p, pCubeMin );
+        // fix the MIC domain from the initial minimized cube
+        Pdr_ManGipSetMicDomain( p, k, pCubeMin );
         // try removing literals
         for ( j = 0; j < pCubeMin->nLits; j++ )
         {
@@ -1122,13 +1191,14 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
                 continue;
 
             // try removing this literal
-            Lit = pCubeMin->Lits[i]; pCubeMin->Lits[i] = -1; 
+            Lit = pCubeMin->Lits[i]; pCubeMin->Lits[i] = -1;
             if ( p->pPars->fSkipDown )
                 RetValue = Pdr_ManCheckCube( p, k, pCubeMin, NULL, p->pPars->nConfLimit, 1, !p->pPars->fSimpleGeneral );
             else
                 RetValue = Pdr_ManCheckCube( p, k, pCubeMin, &pPred, p->pPars->nConfLimit, 1, !p->pPars->fSimpleGeneral );
             if ( RetValue == -1 )
             {
+                Pdr_ManGipUnsetMicDomain( p, k );
                 Pdr_SetDeref( pCubeMin );
                 return -1;
             }
@@ -1137,6 +1207,8 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
             {
                 if ( p->pPars->fSkipDown )
                     continue;
+                // release the fixed domain around 'down'
+                Pdr_ManGipUnsetMicDomain( p, k );
                 pCubeCpy = Pdr_SetCreateFrom( pCubeMin, i );
                 RetValue = ZPdr_ManDown( p, k, &pCubeCpy, pPred, keep, pCubeMin, &added );
                 if ( p->pPars->fCtgs )
@@ -1151,10 +1223,11 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
                 }
                 if ( RetValue == 0 )
                 {
-                    if ( keep ) 
+                    if ( keep )
                         Hash_IntWriteEntry( keep, pCubeMin->Lits[i], 0 );
                     if ( pCubeCpy )
                         Pdr_SetDeref( pCubeCpy );
+                    Pdr_ManGipSetMicDomain( p, k, pCubeMin );
                     continue;
                 }
                 //Inductive subclause
@@ -1163,6 +1236,7 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
                 pCubeMin = pCubeCpy;
                 assert( pCubeMin->nLits > 0 );
                 pOrder = Pdr_ManSortByPriority( p, pCubeMin );
+                Pdr_ManGipSetMicDomain( p, k, pCubeMin );
                 j = -1;
                 continue;
             }
@@ -1172,6 +1246,9 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
             pCubeMin = Pdr_SetCreateFrom( pCubeTmp = pCubeMin, i );
             Pdr_SetDeref( pCubeTmp );
             assert( pCubeMin->nLits > 0 );
+            // re-fix the domain from the shrunk cube
+            Pdr_ManGipUnsetMicDomain( p, k );
+            Pdr_ManGipSetMicDomain( p, k, pCubeMin );
 
             // assume the minimized cube
             if ( p->pPars->fSimpleGeneral )
@@ -1187,38 +1264,47 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
             pOrder = Pdr_ManSortByPriority( p, pCubeMin );
             j--;
         }
+        Pdr_ManGipUnsetMicDomain( p, k );
 
         if ( p->pPars->fTwoRounds )
-        for ( j = 0; j < pCubeMin->nLits; j++ )
         {
-            // use ordering
-    //        i = j;
-            i = pOrder[j];
-
-            // check init state
-            assert( pCubeMin->Lits[i] != -1 );
-            if ( Pdr_SetIsInit(pCubeMin, i) )
-                continue;
-            // try removing this literal
-            Lit = pCubeMin->Lits[i]; pCubeMin->Lits[i] = -1; 
-            RetValue = Pdr_ManCheckCube( p, k, pCubeMin, NULL, p->pPars->nConfLimit, 0, 1 );
-            if ( RetValue == -1 )
+            Pdr_ManGipSetMicDomain( p, k, pCubeMin );
+            for ( j = 0; j < pCubeMin->nLits; j++ )
             {
-                Pdr_SetDeref( pCubeMin );
-                return -1;
+                // use ordering
+        //        i = j;
+                i = pOrder[j];
+
+                // check init state
+                assert( pCubeMin->Lits[i] != -1 );
+                if ( Pdr_SetIsInit(pCubeMin, i) )
+                    continue;
+                // try removing this literal
+                Lit = pCubeMin->Lits[i]; pCubeMin->Lits[i] = -1;
+                RetValue = Pdr_ManCheckCube( p, k, pCubeMin, NULL, p->pPars->nConfLimit, 0, 1 );
+                if ( RetValue == -1 )
+                {
+                    Pdr_ManGipUnsetMicDomain( p, k );
+                    Pdr_SetDeref( pCubeMin );
+                    return -1;
+                }
+                pCubeMin->Lits[i] = Lit;
+                if ( RetValue == 0 )
+                    continue;
+
+                // success - update the cube
+                pCubeMin = Pdr_SetCreateFrom( pCubeTmp = pCubeMin, i );
+                Pdr_SetDeref( pCubeTmp );
+                assert( pCubeMin->nLits > 0 );
+                // re-fix the domain from the shrunk cube
+                Pdr_ManGipUnsetMicDomain( p, k );
+                Pdr_ManGipSetMicDomain( p, k, pCubeMin );
+
+                // get the ordering by decreasing priority
+                pOrder = Pdr_ManSortByPriority( p, pCubeMin );
+                j--;
             }
-            pCubeMin->Lits[i] = Lit;
-            if ( RetValue == 0 )
-                continue;
-
-            // success - update the cube
-            pCubeMin = Pdr_SetCreateFrom( pCubeTmp = pCubeMin, i );
-            Pdr_SetDeref( pCubeTmp );
-            assert( pCubeMin->nLits > 0 );
-
-            // get the ordering by decreasing priority
-            pOrder = Pdr_ManSortByPriority( p, pCubeMin );
-            j--;
+            Pdr_ManGipUnsetMicDomain( p, k );
         }
     }
 

--- a/src/proof/pdr/pdrCore.c
+++ b/src/proof/pdr/pdrCore.c
@@ -232,7 +232,9 @@ int Pdr_ManPushClauses( Pdr_Man_t * p )
             }
 
             // check if the clause can be moved to the next frame
+            p->fGipOrdNow = 1;
             RetValue2 = Pdr_ManCheckCube( p, k, pCubeK, NULL, 0, 0, 1 );
+            p->fGipOrdNow = 0;
             if ( RetValue2 == -1 )
                 return -1;
             if ( !RetValue2 )
@@ -1113,7 +1115,9 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
     *ppCubeMin = NULL;
     if ( p->pPars->fFlopOrder )
         Vec_IntSelectSortPrioReverseLit( pCube->Lits, pCube->nLits, p->vPrio );
+    p->fGipOrdNow = 1;
     RetValue = Pdr_ManCheckCube( p, k, pCube, ppPred, p->pPars->nConfLimit, 0, 1 );
+    p->fGipOrdNow = 0;
     if ( p->pPars->fFlopOrder )
         Vec_IntSelectSort( pCube->Lits, pCube->nLits );
     if ( RetValue == -1 )
@@ -1192,10 +1196,12 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
 
             // try removing this literal
             Lit = pCubeMin->Lits[i]; pCubeMin->Lits[i] = -1;
+            p->fGipOrdNow = 1;
             if ( p->pPars->fSkipDown )
                 RetValue = Pdr_ManCheckCube( p, k, pCubeMin, NULL, p->pPars->nConfLimit, 1, !p->pPars->fSimpleGeneral );
             else
                 RetValue = Pdr_ManCheckCube( p, k, pCubeMin, &pPred, p->pPars->nConfLimit, 1, !p->pPars->fSimpleGeneral );
+            p->fGipOrdNow = 0;
             if ( RetValue == -1 )
             {
                 Pdr_ManGipUnsetMicDomain( p, k );
@@ -1281,7 +1287,9 @@ int Pdr_ManGeneralize( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppP
                     continue;
                 // try removing this literal
                 Lit = pCubeMin->Lits[i]; pCubeMin->Lits[i] = -1;
+                p->fGipOrdNow = 1;
                 RetValue = Pdr_ManCheckCube( p, k, pCubeMin, NULL, p->pPars->nConfLimit, 0, 1 );
+                p->fGipOrdNow = 0;
                 if ( RetValue == -1 )
                 {
                     Pdr_ManGipUnsetMicDomain( p, k );

--- a/src/proof/pdr/pdrInt.h
+++ b/src/proof/pdr/pdrInt.h
@@ -31,6 +31,7 @@
 #include "pdr.h" 
 #include "misc/hash/hashInt.h"
 #include "aig/gia/giaAig.h"
+#include "gipsat/gipsat.h"
 
 //#define PDR_USE_SATOKO 1
 
@@ -124,6 +125,10 @@ struct Pdr_Man_t_
     Vec_Int_t * vMapPpi2Ff;
     int         nCexes;
     int         nCexesTotal;
+    // GipSAT (fUseGipSat): shared static context + one persistent solver per frame
+    Gip_Ctx_t * pGipCtx;
+    Vec_Ptr_t * vGipSolvers;
+    Vec_Int_t * vGipLits;  // scratch (constraint clause literals)
     // terminary simulation
     Txs3_Man_t * pTxs3;      
     // internal use
@@ -226,6 +231,8 @@ extern void            Pdr_ManSolverAddClause( Pdr_Man_t * p, int k, Pdr_Set_t *
 extern void            Pdr_ManCollectValues( Pdr_Man_t * p, int k, Vec_Int_t * vObjIds, Vec_Int_t * vValues );
 extern int             Pdr_ManCheckCubeCs( Pdr_Man_t * p, int k, Pdr_Set_t * pCube );
 extern int             Pdr_ManCheckCube( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppPred, int nConfLimit, int fTryConf, int fUseLit );
+extern Gip_Solver_t *  Pdr_ManGipSolver( Pdr_Man_t * p, int k );
+extern Vec_Int_t *     Pdr_ManGipCubeToLits( Pdr_Man_t * p, Pdr_Set_t * pCube, int fCompl, int fNext, Vec_Int_t * vOut );
 /*=== pdrTsim.c ==========================================================*/
 extern Pdr_Set_t *     Pdr_ManTernarySim( Pdr_Man_t * p, int k, Pdr_Set_t * pCube );
 /*=== pdrTsim2.c ==========================================================*/

--- a/src/proof/pdr/pdrInt.h
+++ b/src/proof/pdr/pdrInt.h
@@ -129,6 +129,8 @@ struct Pdr_Man_t_
     Gip_Ctx_t * pGipCtx;
     Vec_Ptr_t * vGipSolvers;
     Vec_Int_t * vGipLits;  // scratch (constraint clause literals)
+    Vec_Int_t * vGipOrder; // scratch (assumption ordering)
+    int         fGipOrdNow;// with fFlopOrder: this query orders assumptions by vPrio (desc)
     // terminary simulation
     Txs3_Man_t * pTxs3;      
     // internal use
@@ -233,6 +235,7 @@ extern int             Pdr_ManCheckCubeCs( Pdr_Man_t * p, int k, Pdr_Set_t * pCu
 extern int             Pdr_ManCheckCube( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppPred, int nConfLimit, int fTryConf, int fUseLit );
 extern Gip_Solver_t *  Pdr_ManGipSolver( Pdr_Man_t * p, int k );
 extern Vec_Int_t *     Pdr_ManGipCubeToLits( Pdr_Man_t * p, Pdr_Set_t * pCube, int fCompl, int fNext, Vec_Int_t * vOut );
+extern Vec_Int_t *     Pdr_ManGipCubeToLitsOrdered( Pdr_Man_t * p, Pdr_Set_t * pCube, int fCompl, int fNext, Vec_Int_t * vOut );
 /*=== pdrTsim.c ==========================================================*/
 extern Pdr_Set_t *     Pdr_ManTernarySim( Pdr_Man_t * p, int k, Pdr_Set_t * pCube );
 /*=== pdrTsim2.c ==========================================================*/

--- a/src/proof/pdr/pdrMan.c
+++ b/src/proof/pdr/pdrMan.c
@@ -280,6 +280,18 @@ Pdr_Man_t * Pdr_ManStart( Aig_Man_t * pAig, Pdr_Par_t * pPars, Vec_Int_t * vPrio
     p->vCi2Rem  = Vec_IntAlloc( 100 );  // CIs to be removed
     p->vRes     = Vec_IntAlloc( 100 );  // final result
     p->pCnfMan  = Cnf_ManStart();
+    // GipSAT shared context (static CNF + dep table)
+    if ( pPars->fUseGipSat && (pPars->fNewXSim || pPars->fUseAbs || pPars->fUseSimpleRef || pPars->fSimpleGeneral) )
+    {
+        Abc_Print( 0, "GipSAT (-s) does not support -u/-t/-k/-j; disabling GipSAT.\n" );
+        pPars->fUseGipSat = 0;
+    }
+    if ( pPars->fUseGipSat )
+    {
+        p->pGipCtx     = Gip_CtxCreate( pAig, p->pCnfMan );
+        p->vGipSolvers = Vec_PtrAlloc( 0 );
+        p->vGipLits    = Vec_IntAlloc( 100 );
+    }
     // ternary simulation
     p->pTxs3    = pPars->fNewXSim ? Txs3_ManStart( p, pAig, p->vPrio ) : NULL;
     // additional AIG data-members
@@ -342,6 +354,15 @@ void Pdr_ManStop( Pdr_Man_t * p )
     Vec_PtrForEachEntry( sat_solver *, p->vSolvers, pSat, i )
         sat_solver_delete( pSat );
     Vec_PtrFree( p->vSolvers );
+    if ( p->vGipSolvers )
+    {
+        Gip_Solver_t * pGip;
+        Vec_PtrForEachEntry( Gip_Solver_t *, p->vGipSolvers, pGip, i )
+            Gip_SolverFree( pGip );
+        Vec_PtrFree( p->vGipSolvers );
+    }
+    Gip_CtxFree( p->pGipCtx );
+    Vec_IntFreeP( &p->vGipLits );
     Vec_VecForEachEntry( Pdr_Set_t *, p->vClauses, pCla, i, k )
         Pdr_SetDeref( pCla );
     Vec_VecFree( p->vClauses );

--- a/src/proof/pdr/pdrMan.c
+++ b/src/proof/pdr/pdrMan.c
@@ -291,6 +291,7 @@ Pdr_Man_t * Pdr_ManStart( Aig_Man_t * pAig, Pdr_Par_t * pPars, Vec_Int_t * vPrio
         p->pGipCtx     = Gip_CtxCreate( pAig, p->pCnfMan );
         p->vGipSolvers = Vec_PtrAlloc( 0 );
         p->vGipLits    = Vec_IntAlloc( 100 );
+        p->vGipOrder   = Vec_IntAlloc( 100 );
     }
     // ternary simulation
     p->pTxs3    = pPars->fNewXSim ? Txs3_ManStart( p, pAig, p->vPrio ) : NULL;
@@ -363,6 +364,7 @@ void Pdr_ManStop( Pdr_Man_t * p )
     }
     Gip_CtxFree( p->pGipCtx );
     Vec_IntFreeP( &p->vGipLits );
+    Vec_IntFreeP( &p->vGipOrder );
     Vec_VecForEachEntry( Pdr_Set_t *, p->vClauses, pCla, i, k )
         Pdr_SetDeref( pCla );
     Vec_VecFree( p->vClauses );

--- a/src/proof/pdr/pdrSat.c
+++ b/src/proof/pdr/pdrSat.c
@@ -82,6 +82,64 @@ Vec_Int_t * Pdr_ManGipCubeToLits( Pdr_Man_t * p, Pdr_Set_t * pCube, int fCompl, 
 
 /**Function*************************************************************
 
+  Synopsis    [Converts a register cube into GipSAT literals, ordered by vPrio.]
+
+  Description [Used with fFlopOrder: mirrors rIC3's with_act_order
+  queries, which sort the cube by IC3 activity (descending) before
+  converting to assumptions. GipSAT places assumptions one decision
+  level at a time in the given order, so the order steers where
+  conflicts occur and hence which unsat core is produced. Ties broken
+  by flop index ascending. Does not touch the Pdr_Set itself.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+Vec_Int_t * Pdr_ManGipCubeToLitsOrdered( Pdr_Man_t * p, Pdr_Set_t * pCube, int fCompl, int fNext, Vec_Int_t * vOut )
+{
+    Aig_Obj_t * pObj;
+    int i, j, best, iVar, Lit, LitB;
+    Vec_Int_t * vIdx = p->vGipOrder;
+    Vec_IntClear( vIdx );
+    for ( i = 0; i < pCube->nLits; i++ )
+        if ( pCube->Lits[i] != -1 )
+            Vec_IntPush( vIdx, i );
+    for ( i = 0; i < Vec_IntSize(vIdx) - 1; i++ )
+    {
+        best = i;
+        for ( j = i + 1; j < Vec_IntSize(vIdx); j++ )
+        {
+            Lit  = pCube->Lits[Vec_IntEntry(vIdx, j)];
+            LitB = pCube->Lits[Vec_IntEntry(vIdx, best)];
+            if (  Vec_IntEntry(p->vPrio, Lit >> 1) >  Vec_IntEntry(p->vPrio, LitB >> 1) ||
+                 (Vec_IntEntry(p->vPrio, Lit >> 1) == Vec_IntEntry(p->vPrio, LitB >> 1) && Lit < LitB) )
+                best = j;
+        }
+        if ( best != i )
+        {
+            int Tmp = Vec_IntEntry( vIdx, i );
+            Vec_IntWriteEntry( vIdx, i, Vec_IntEntry(vIdx, best) );
+            Vec_IntWriteEntry( vIdx, best, Tmp );
+        }
+    }
+    Vec_IntClear( vOut );
+    Vec_IntForEachEntry( vIdx, j, i )
+    {
+        Lit = pCube->Lits[j];
+        if ( fNext )
+            pObj = Saig_ManLi( p->pAig, Abc_Lit2Var(Lit) );
+        else
+            pObj = Saig_ManLo( p->pAig, Abc_Lit2Var(Lit) );
+        iVar = Gip_ObjVar( pObj );
+        assert( iVar >= 0 );
+        Vec_IntPush( vOut, Abc_Var2Lit( iVar, fCompl ^ Abc_LitIsCompl(Lit) ) );
+    }
+    return vOut;
+}
+
+/**Function*************************************************************
+
   Synopsis    [Creates new SAT solver.]
 
   Description []
@@ -435,7 +493,10 @@ int Pdr_ManCheckCube( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppPr
                 nCstLits[0] = Vec_IntSize( p->vGipLits );
                 nCst = 1;
             }
-            vLits = Pdr_ManGipCubeToLits( p, pCube, 0, 1, p->vLits );
+            if ( p->pPars->fFlopOrder && p->fGipOrdNow )
+                vLits = Pdr_ManGipCubeToLitsOrdered( p, pCube, 0, 1, p->vLits );
+            else
+                vLits = Pdr_ManGipCubeToLits( p, pCube, 0, 1, p->vLits );
             clk = Abc_Clock();
             pGip->nConfLimit = fTryConf ? p->pPars->nConfGenLimit : nConfLimit;
             pGip->TimeLimit  = Pdr_ManTimeLimit( p );

--- a/src/proof/pdr/pdrSat.c
+++ b/src/proof/pdr/pdrSat.c
@@ -33,6 +33,55 @@ ABC_NAMESPACE_IMPL_START
 
 /**Function*************************************************************
 
+  Synopsis    [Returns the GipSAT solver of the given frame.]
+
+  Description []
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+Gip_Solver_t * Pdr_ManGipSolver( Pdr_Man_t * p, int k )
+{
+    return (Gip_Solver_t *)Vec_PtrEntry( p->vGipSolvers, k );
+}
+
+/**Function*************************************************************
+
+  Synopsis    [Converts a register cube into GipSAT literals.]
+
+  Description [Mirror of Pdr_ManCubeToLits, but uses the static
+  frame-independent variable numbering of the GipSAT context
+  (var == object id) and never mutates any solver. Fills vOut.]
+
+  SideEffects []
+
+  SeeAlso     []
+
+***********************************************************************/
+Vec_Int_t * Pdr_ManGipCubeToLits( Pdr_Man_t * p, Pdr_Set_t * pCube, int fCompl, int fNext, Vec_Int_t * vOut )
+{
+    Aig_Obj_t * pObj;
+    int i, iVar;
+    Vec_IntClear( vOut );
+    for ( i = 0; i < pCube->nLits; i++ )
+    {
+        if ( pCube->Lits[i] == -1 )
+            continue;
+        if ( fNext )
+            pObj = Saig_ManLi( p->pAig, Abc_Lit2Var(pCube->Lits[i]) );
+        else
+            pObj = Saig_ManLo( p->pAig, Abc_Lit2Var(pCube->Lits[i]) );
+        iVar = Gip_ObjVar( pObj );
+        assert( iVar >= 0 );
+        Vec_IntPush( vOut, Abc_Var2Lit( iVar, fCompl ^ Abc_LitIsCompl(pCube->Lits[i]) ) );
+    }
+    return vOut;
+}
+
+/**Function*************************************************************
+
   Synopsis    [Creates new SAT solver.]
 
   Description []
@@ -57,6 +106,24 @@ sat_solver * Pdr_ManCreateSolver( Pdr_Man_t * p, int k )
     Vec_PtrPush( p->vSolvers, pSat );
     Vec_VecExpand( p->vClauses, k );
     Vec_IntPush( p->vActVars, 0 );
+    // create the persistent GipSAT solver of this frame (never recycled)
+    if ( p->pPars->fUseGipSat )
+    {
+        Gip_Solver_t * pGip;
+        assert( Vec_PtrSize(p->vGipSolvers) == k );
+        pGip = Gip_SolverNew( p->pGipCtx );
+        if ( k == 0 )
+        {
+            // initial states: all registers are 0, added as unit lemmas
+            int Lit;
+            Saig_ManForEachLo( p->pAig, pObj, i )
+            {
+                Lit = Abc_Var2Lit( Gip_ObjVar(pObj), 1 );
+                Gip_SolverAddLemma( pGip, &Lit, 1 );
+            }
+        }
+        Vec_PtrPush( p->vGipSolvers, pGip );
+    }
     // add property cone
     Saig_ManForEachPo( p->pAig, pObj, i )
         Pdr_ObjSatVar( p, k, 1, pObj );
@@ -215,6 +282,12 @@ void Pdr_ManSolverAddClause( Pdr_Man_t * p, int k, Pdr_Set_t * pCube )
     sat_solver * pSat;
     Vec_Int_t * vLits;
     int RetValue;
+    if ( p->pPars->fUseGipSat )
+    {
+        vLits = Pdr_ManGipCubeToLits( p, pCube, 1, 0, p->vLits );
+        Gip_SolverAddLemma( Pdr_ManGipSolver(p, k), Vec_IntArray(vLits), Vec_IntSize(vLits) );
+        return;
+    }
     pSat  = Pdr_ManSolver(p, k);
     vLits = Pdr_ManCubeToLits( p, k, pCube, 1, 0 );
     RetValue = sat_solver_addclause( pSat, Vec_IntArray(vLits), Vec_IntArray(vLits) + Vec_IntSize(vLits) );
@@ -239,6 +312,18 @@ void Pdr_ManCollectValues( Pdr_Man_t * p, int k, Vec_Int_t * vObjIds, Vec_Int_t 
     Aig_Obj_t * pObj;
     int iVar, i;
     Vec_IntClear( vValues );
+    if ( p->pPars->fUseGipSat )
+    {
+        // model values from the GipSAT solver; unassigned (outside the
+        // domain, hence outside the queried cone) default to 0
+        Gip_Solver_t * pGip = Pdr_ManGipSolver( p, k );
+        Aig_ManForEachObjVec( vObjIds, p->pAig, pObj, i )
+        {
+            iVar = Gip_ObjVar( pObj ); assert( iVar >= 0 );
+            Vec_IntPush( vValues, Gip_SolverVarValue(pGip, iVar) );
+        }
+        return;
+    }
     pSat = Pdr_ManSolver(p, k);
     Aig_ManForEachObjVec( vObjIds, p->pAig, pObj, i )
     {
@@ -265,6 +350,17 @@ int Pdr_ManCheckCubeCs( Pdr_Man_t * p, int k, Pdr_Set_t * pCube )
     Vec_Int_t * vLits;
     abctime Limit;
     int RetValue;
+    if ( p->pPars->fUseGipSat )
+    {
+        Gip_Solver_t * pGip = Pdr_ManGipSolver( p, k );
+        vLits = Pdr_ManGipCubeToLits( p, pCube, 0, 0, p->vLits );
+        pGip->nConfLimit = 0;
+        pGip->TimeLimit  = Pdr_ManTimeLimit( p );
+        RetValue = Gip_SolverSolve( pGip, Vec_IntArray(vLits), Vec_IntSize(vLits), NULL, NULL, 0, -1 );
+        if ( RetValue == GIP_UNDEF )
+            return -1;
+        return (RetValue == GIP_UNSAT);
+    }
     pSat = Pdr_ManFetchSolver( p, k );
     vLits = Pdr_ManCubeToLits( p, k, pCube, 0, 0 );
     Limit = sat_solver_set_runtime_limit( pSat, Pdr_ManTimeLimit(p) );
@@ -300,10 +396,22 @@ int Pdr_ManCheckCube( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppPr
     if ( pCube == NULL ) // solve the property
     {
         clk = Abc_Clock();
-        Lit = Abc_Var2Lit( Pdr_ObjSatVar(p, k, 2, Aig_ManCo(p->pAig, p->iOutCur)), 0 ); // pos literal (property fails)
-        Limit = sat_solver_set_runtime_limit( pSat, Pdr_ManTimeLimit(p) );
-        RetValue = sat_solver_solve( pSat, &Lit, &Lit + 1, nConfLimit, 0, 0, 0 );
-        sat_solver_set_runtime_limit( pSat, Limit );
+        if ( p->pPars->fUseGipSat )
+        {
+            Gip_Solver_t * pGip = Pdr_ManGipSolver( p, k );
+            Lit = Abc_Var2Lit( Gip_ObjVar(Aig_ManCo(p->pAig, p->iOutCur)), 0 ); // pos literal (property fails)
+            pGip->nConfLimit = nConfLimit;
+            pGip->TimeLimit  = Pdr_ManTimeLimit( p );
+            RetValue = Gip_SolverSolve( pGip, &Lit, 1, NULL, NULL, 0, -1 );
+            RetValue = RetValue == GIP_SAT ? l_True : (RetValue == GIP_UNSAT ? l_False : l_Undef);
+        }
+        else
+        {
+            Lit = Abc_Var2Lit( Pdr_ObjSatVar(p, k, 2, Aig_ManCo(p->pAig, p->iOutCur)), 0 ); // pos literal (property fails)
+            Limit = sat_solver_set_runtime_limit( pSat, Pdr_ManTimeLimit(p) );
+            RetValue = sat_solver_solve( pSat, &Lit, &Lit + 1, nConfLimit, 0, 0, 0 );
+            sat_solver_set_runtime_limit( pSat, Limit );
+        }
         if ( RetValue == l_Undef )
             return -1;
         if ( p->pPars->pFuncProgress && p->pPars->pFuncProgress( p->pPars->pProgress, 0, (unsigned)k ) )
@@ -311,32 +419,58 @@ int Pdr_ManCheckCube( Pdr_Man_t * p, int k, Pdr_Set_t * pCube, Pdr_Set_t ** ppPr
     }
     else // check relative containment in terms of next states
     {
-        if ( fUseLit )
+        if ( p->pPars->fUseGipSat )
         {
-            fLitUsed = 1;
-            Vec_IntAddToEntry( p->vActVars, k, 1 );
-            // add the cube in terms of current state variables
-            vLits = Pdr_ManCubeToLits( p, k, pCube, 1, 0 );
-            // add activation literal
-            Lit = Abc_Var2Lit( Pdr_ManFreeVar(p, k), 0 );
-            // add activation literal
-            Vec_IntPush( vLits, Lit );
-            RetValue = sat_solver_addclause( pSat, Vec_IntArray(vLits), Vec_IntArray(vLits) + Vec_IntSize(vLits) );
-            assert( RetValue == 1 );
-            sat_solver_compress( pSat );
-            // create assumptions
-            vLits = Pdr_ManCubeToLits( p, k, pCube, 0, 1 );
-            // add activation literal
-            Vec_IntPush( vLits, Abc_LitNot(Lit) );
+            // assumptions are the next-state literals of the cube; with
+            // fUseLit, the negated cube is passed as a temporary constraint
+            // clause instead of a permanent activation-literal clause;
+            // vGipLits must stay distinct from vLits: the solver reads the
+            // constraint clause and the assumptions at the same time
+            Gip_Solver_t * pGip = Pdr_ManGipSolver( p, k );
+            int * pCstCls[1]; int nCstLits[1]; int nCst = 0;
+            if ( fUseLit )
+            {
+                Pdr_ManGipCubeToLits( p, pCube, 1, 0, p->vGipLits );
+                pCstCls[0]  = Vec_IntArray( p->vGipLits );
+                nCstLits[0] = Vec_IntSize( p->vGipLits );
+                nCst = 1;
+            }
+            vLits = Pdr_ManGipCubeToLits( p, pCube, 0, 1, p->vLits );
+            clk = Abc_Clock();
+            pGip->nConfLimit = fTryConf ? p->pPars->nConfGenLimit : nConfLimit;
+            pGip->TimeLimit  = Pdr_ManTimeLimit( p );
+            RetValue = Gip_SolverSolve( pGip, Vec_IntArray(vLits), Vec_IntSize(vLits), pCstCls, nCstLits, nCst, -1 );
+            RetValue = RetValue == GIP_SAT ? l_True : (RetValue == GIP_UNSAT ? l_False : l_Undef);
         }
         else
-            vLits = Pdr_ManCubeToLits( p, k, pCube, 0, 1 );
+        {
+            if ( fUseLit )
+            {
+                fLitUsed = 1;
+                Vec_IntAddToEntry( p->vActVars, k, 1 );
+                // add the cube in terms of current state variables
+                vLits = Pdr_ManCubeToLits( p, k, pCube, 1, 0 );
+                // add activation literal
+                Lit = Abc_Var2Lit( Pdr_ManFreeVar(p, k), 0 );
+                // add activation literal
+                Vec_IntPush( vLits, Lit );
+                RetValue = sat_solver_addclause( pSat, Vec_IntArray(vLits), Vec_IntArray(vLits) + Vec_IntSize(vLits) );
+                assert( RetValue == 1 );
+                sat_solver_compress( pSat );
+                // create assumptions
+                vLits = Pdr_ManCubeToLits( p, k, pCube, 0, 1 );
+                // add activation literal
+                Vec_IntPush( vLits, Abc_LitNot(Lit) );
+            }
+            else
+                vLits = Pdr_ManCubeToLits( p, k, pCube, 0, 1 );
 
-        // solve 
-        clk = Abc_Clock();
-        Limit = sat_solver_set_runtime_limit( pSat, Pdr_ManTimeLimit(p) );
-        RetValue = sat_solver_solve( pSat, Vec_IntArray(vLits), Vec_IntArray(vLits) + Vec_IntSize(vLits), fTryConf ? p->pPars->nConfGenLimit : nConfLimit, 0, 0, 0 );
-        sat_solver_set_runtime_limit( pSat, Limit );
+            // solve
+            clk = Abc_Clock();
+            Limit = sat_solver_set_runtime_limit( pSat, Pdr_ManTimeLimit(p) );
+            RetValue = sat_solver_solve( pSat, Vec_IntArray(vLits), Vec_IntArray(vLits) + Vec_IntSize(vLits), fTryConf ? p->pPars->nConfGenLimit : nConfLimit, 0, 0, 0 );
+            sat_solver_set_runtime_limit( pSat, Limit );
+        }
         if ( RetValue == l_Undef )
         {
             if ( fTryConf && p->pPars->nConfGenLimit )


### PR DESCRIPTION
Add GipSAT (rIC3's IC3-specialized SAT solver) as an optional PDR backend

This PR adds GipSAT, an IC3-specialized CDCL solver, as an optional SAT backend for `pdr`. It is selected with a new switch, `-s`, and is off by default; without `-s` the behavior of `pdr` is unchanged.

**Origin and license.** GipSAT is the solver described in "Deeply Optimizing the SAT Solver for the IC3 Algorithm" (CAV 2025); this is a C port of its implementation, which lives in the [rIC3](https://github.com/gipsyh/rIC3) repository (`src/gipsat/`). That code is GPL-3.0; its author has given written permission to distribute the port under the ABC license, as recorded in the file headers.

**Usage.** `pdr -s` answers all PDR SAT queries with GipSAT. Using the existing `-f` together with it is recommended: with `-s`, `-f` sorts the cube literals by activity before each query, as rIC3 does, which steers which unsat core the solver returns. `pdr -sf` is the intended configuration.

**Commits.**

1. `pdr: add GipSAT, an IC3-specialized SAT solver ported from rIC3` — the engine itself, self-contained, not yet used by PDR. The message lists every deviation from rIC3.
2. `GipSAT: cancel a solve only in a conflict-free state` — moves the conflict-limit and time-limit checks out of the conflict branch; the message explains the failure it prevents and why ABC's own `sat_solver` is not affected.
3. `pdr: use GipSAT as an alternative query backend (pdr -s)` — the integration into PDR.
4. `pdr -s: honor -f activity ordering` — the query ordering.

**Results.** HWMCC25 bit-level set (330 cases), 3600 s per case, 16 cases in parallel on one machine, comparing `pdr -f` with `pdr -sf`:

- Solved: 197 vs 198. On the 187 cases both configurations solve, `pdr -sf` is about 1.4x faster (geometric mean of per-case time ratios).
- The two engines are complementary: each solves about 10 cases the other does not, and the best of the two would solve 208.
- Both issue essentially the same number of SAT queries; GipSAT answers them about 1.45x faster per query.
- Correctness: no verdict disagreement in any of the configurations run (six configurations over the 330 cases); every UNSAT result was re-verified by checking the inductive invariant with an independent solver, and every counterexample was replayed.

These figures were measured on the pre-rebase tree; the rebased branch reproduces the same verdicts on all 330 cases.

**Known costs and limitations.**

- Memory: GipSAT keeps one persistent solver per frame over the full CNF of the design, so its memory is in the class of ABC's `-m` mode: typically 1-2x the lazy default, 3-7x on large industrial designs (about 6 GB peak observed). With a 10 GB per-case limit, 5 of the 330 cases exceed it.
- Search trajectories are not identical to rIC3's: the decide polarity is zero with phase saving (the policy of ABC's own solver) instead of rIC3's random polarity, and one learned-clause watch tie-break differs; both are documented in the first commit message. rIC3's `flip_to_none` is not ported.
